### PR TITLE
Fix for https://github.com/wso2/product-apim/issues/8834

### DIFF
--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
@@ -52,8 +52,8 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         appRegistrationRequest.setGrantTypes(registrationRequestDTO.getGrantTypes());
         appRegistrationRequest.setTokenType(registrationRequestDTO.getTokenTypeExtension());
         appRegistrationRequest.setApplicationOwner(registrationRequestDTO.getExtApplicationOwner());
-        appRegistrationRequest.setConsumerKey(registrationRequestDTO.getClientId());
-        appRegistrationRequest.setConsumerSecret(registrationRequestDTO.getClientSecret());
+        appRegistrationRequest.setConsumerKey(registrationRequestDTO.getExtParamClientId());
+        appRegistrationRequest.setConsumerSecret(registrationRequestDTO.getExtParamClientSecret());
         appRegistrationRequest.setSpTemplateName(registrationRequestDTO.getExtParamSpTemplate());
         appRegistrationRequest.setBackchannelLogoutUri(registrationRequestDTO.getBackchannelLogoutUri());
         return appRegistrationRequest;


### PR DESCRIPTION
## Purpose
When importing an app that has already generated keys should retain the original keys after importing.
But, instead, new keys are generated. This PR will solve this issue.

## Goals
Fixes https://github.com/wso2/product-apim/issues/8834

