### PR TITLE
Expanding carbon.apimgt.imp.pkg range to [6.7.0, 10.0.0)

### DIFF
--- a/components/wso2is.key.manager/pom.xml
+++ b/components/wso2is.key.manager/pom.xml
@@ -43,6 +43,7 @@
                             org.wso2.is.client.*;version="1.0.0"
                         </Export-Package>
                         <Import-Package>
+                            org.wso2.carbon.apimgt.api.*;version="${carbon.apimgt.imp.pkg.version}",
                             org.wso2.carbon.apimgt.impl.*;version="${carbon.apimgt.imp.pkg.version}",
                             org.wso2.carbon.apimgt.notification.*;version="${carbon.apimgt.imp.pkg.version}",
                             org.apache.commons.codec.*,

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,6 @@
         <version.checkstyle>8.34</version.checkstyle>
         <io.swagger.codegen.version>2.4.11</io.swagger.codegen.version>
         <identity.auth.rest.version>1.4.0</identity.auth.rest.version>
-        <carbon.apimgt.imp.pkg.version>[6.0.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
+        <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Expanding carbon.apimgt.imp.pkg range to [6.7.0, 10.0.0) includes support for APIM 3.2 and 4.0

