### PR TITLE
Adding a handler to clear the the extensions caches along with a CacheProvider

### DIFF
--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/handlers/TenantConfigMediaTypeHandler.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/handlers/TenantConfigMediaTypeHandler.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.is.key.manager.core.handlers;
+
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.registry.core.jdbc.handlers.Handler;
+import org.wso2.carbon.registry.core.jdbc.handlers.RequestContext;
+import org.wso2.is.key.manager.core.tokenmgt.handlers.ResourceConstants;
+import org.wso2.is.key.manager.core.tokenmgt.util.CacheProvider;
+
+import javax.cache.Cache;
+
+/**
+ * Handler class to clear the extensions caches when tenant-config is updated
+ */
+public class TenantConfigMediaTypeHandler extends Handler {
+
+    public void put(RequestContext requestContext) {
+        clearConfigCache();
+    }
+
+    public void delete(RequestContext requestContext) {
+        clearConfigCache();
+    }
+
+    private void clearConfigCache() {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        String cacheKey = tenantId + "_" + ResourceConstants.TENANT_CONFIG_CACHE_NAME;
+        boolean tenantFlowStarted = false;
+
+        if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            try {
+                PrivilegedCarbonContext.startTenantFlow();
+                tenantFlowStarted = true;
+                PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+                carbonContext.setTenantDomain(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+                carbonContext.setTenantId(MultitenantConstants.SUPER_TENANT_ID);
+                // Clear the necessary caches of the extensions
+                clearExtensionsManagerCaches(cacheKey, tenantDomain);
+            } finally {
+                if (tenantFlowStarted) {
+                    PrivilegedCarbonContext.endTenantFlow();
+                }
+            }
+        } else {
+            // Clear the necessary caches of the extensions
+            clearExtensionsManagerCaches(cacheKey, tenantDomain);
+        }
+    }
+
+    private void clearExtensionsManagerCaches(String cacheKey, String tenantDomain) {
+        // Clear the tenant-config cache of the extensions
+        Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
+        tenantConfigCache.remove(cacheKey);
+
+        // Clear the REST API Scope cache of the extensions
+        Cache restApiScopesCache = CacheProvider.getRESTAPIScopeCache();
+        restApiScopesCache.remove(tenantDomain);
+    }
+}

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/handlers/TenantConfigMediaTypeHandler.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/handlers/TenantConfigMediaTypeHandler.java
@@ -67,11 +67,11 @@ public class TenantConfigMediaTypeHandler extends Handler {
 
     private void clearExtensionsManagerCaches(String cacheKey, String tenantDomain) {
         // Clear the tenant-config cache of the extensions
-        Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
+        Cache tenantConfigCache = CacheProvider.getInstance().getTenantConfigCache();
         tenantConfigCache.remove(cacheKey);
 
         // Clear the REST API Scope cache of the extensions
-        Cache restApiScopesCache = CacheProvider.getRESTAPIScopeCache();
+        Cache restApiScopesCache = CacheProvider.getInstance().getRESTAPIScopeCache();
         restApiScopesCache.remove(tenantDomain);
     }
 }

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/CacheProvider.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/CacheProvider.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.is.key.manager.core.tokenmgt.util;
+
+import org.wso2.is.key.manager.core.tokenmgt.handlers.ResourceConstants;
+
+import javax.cache.Cache;
+import javax.cache.Caching;
+
+/**
+ * Class for initiating and returning caches. Creating cache take place when super tenant loading and tenant loading
+ */
+public class CacheProvider {
+
+    /**
+     * @return Tenant Config cache
+     */
+    public static Cache getTenantConfigCache() {
+        return getCache(ResourceConstants.TENANT_CONFIG_CACHE_NAME);
+    }
+
+    /**
+     * @return Product REST API scope cache
+     */
+    public static Cache getRESTAPIScopeCache() {
+        return getCache(ResourceConstants.REST_API_SCOPE_CACHE);
+    }
+
+    /**
+     * @param cacheName name of the requested cache
+     * @return cache
+     */
+    private static Cache getCache(final String cacheName) {
+        return Caching.getCacheManager(ResourceConstants.EXTENTIONS_CACHE_MANAGER).getCache(cacheName);
+    }
+
+}

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/CacheProvider.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/CacheProvider.java
@@ -27,6 +27,24 @@ import javax.cache.Caching;
  */
 public class CacheProvider {
 
+    private static CacheProvider INSTANCE = null;
+
+    private CacheProvider() {
+    }
+
+    /**
+     * Method to get the instance of the CacheProvider.
+     *
+     * @return {@link CacheProvider} instance
+     */
+    public static CacheProvider getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new CacheProvider();
+        }
+
+        return INSTANCE;
+    }
+
     /**
      * @return Tenant Config cache
      */

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/TokenMgtUtil.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/TokenMgtUtil.java
@@ -286,7 +286,14 @@ public class TokenMgtUtil {
         return restAPIConfigJSON;
     }
 
-    public static JSONObject getTenantConfig(String tenantDomain) throws TokenMgtException {
+    /**
+     * Returns the tenant-conf.json in JSONObject format for the given tenant domain from the registry.
+     *
+     * @param tenantDomain Tenant domain
+     * @return tenant-conf.json in JSONObject format for the given tenant domain
+     * @throws TokenMgtException If an error occurs while getting the tenant config from registry for tenant
+     */
+    private static JSONObject getTenantConfig(String tenantDomain) throws TokenMgtException {
 
         int tenantId = getTenantIdFromTenantDomain(tenantDomain);
         boolean tenantFlowStarted = false;

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/TokenMgtUtil.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/util/TokenMgtUtil.java
@@ -192,7 +192,7 @@ public class TokenMgtUtil {
     public static Map<String, String> getRESTAPIScopesForTenant(String tenantDomain) throws TokenMgtException {
 
         Map<String, String> restAPIScopes;
-        restAPIScopes = (Map) CacheProvider.getRESTAPIScopeCache().get(tenantDomain);
+        restAPIScopes = (Map) CacheProvider.getInstance().getRESTAPIScopeCache().get(tenantDomain);
         if (restAPIScopes == null) {
 
             restAPIScopes = getRESTAPIScopesFromConfig(getTenantRESTAPIScopesConfig(tenantDomain),
@@ -298,7 +298,7 @@ public class TokenMgtUtil {
         int tenantId = getTenantIdFromTenantDomain(tenantDomain);
         boolean tenantFlowStarted = false;
         try {
-            Cache tenantConfigCache = CacheProvider.getTenantConfigCache();
+            Cache tenantConfigCache = CacheProvider.getInstance().getTenantConfigCache();
             String cacheName = tenantId + "_" + ResourceConstants.TENANT_CONFIG_CACHE_NAME;
             if (tenantConfigCache.containsKey(cacheName)) {
                 return (JSONObject) tenantConfigCache.get(cacheName);


### PR DESCRIPTION
## Purpose
Fix:
https://github.com/wso2/product-apim/issues/10549
https://github.com/wso2/product-apim/issues/10640

## Goals
Clear the REST API scopes and tenant-conf caches of the extensions cache using a handler and add a cache provider.

## Approach
- Added a CacheProvider to handle extensions cache-related functions.
- The REST API Scopes cache has been cleared from the extensions cache by adding a new registry handler named TenantConfigMediaTypeHandler.
- The tenant config cache has been cleared from the extensions cache by adding a new registry handler named TenantConfigMediaTypeHandler.
- Starting tenant flows where necessary (Ex; When clearing the caches using the handler and when retrieving the tenant-config.json from the registry).

## Related PRs
https://github.com/wso2/product-apim/pull/10750

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS
