### PR TITLE
Fix issue in exchange token without scopes

### DIFF
--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuer.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuer.java
@@ -337,7 +337,7 @@ public class RoleBasedScopesIssuer extends AbstractScopesIssuer implements Scope
     public List<String> getScopes(OAuthTokenReqMessageContext tokReqMsgCtx) {
 
         List<String> authorizedScopes = null;
-        List<String> requestedScopes = Arrays.asList(tokReqMsgCtx.getScope());
+        List<String> requestedScopes = new ArrayList<>(Arrays.asList(tokReqMsgCtx.getScope()));
         String clientId = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getClientId();
         AuthenticatedUser authenticatedUser = tokReqMsgCtx.getAuthorizedUser();
         Map<String, String> appScopes = getAppScopes(clientId, authenticatedUser, requestedScopes);


### PR DESCRIPTION
## Purpose

Fixes $subject. (Without this fix, it throws `java.lang.UnsupportedOperationException` when trying to add scope in [1].

[1] https://github.com/wso2-extensions/apim-km-wso2is/blob/master/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/issuers/AbstractScopesIssuer.java#L90