### PR TITLE
Add Audit logs for token exchange flow

### DIFF
--- a/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/APIMTokenExchangeAuditLogger.java
+++ b/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/APIMTokenExchangeAuditLogger.java
@@ -98,12 +98,15 @@ public class APIMTokenExchangeAuditLogger extends AbstractOAuthEventInterceptor 
                 if (signedJWT.getJWTClaimsSet() != null) {
                     JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
                     entityInfo.put(AuditLogConstants.ISSUER, claimsSet.getIssuer());
-                    entityInfo.put(AuditLogConstants.AUDIENCE, claimsSet.getAudience());
-                    entityInfo.put(AuditLogConstants.JWT_ID, claimsSet.getJWTID());
+                    entityInfo.put(AuditLogConstants.AUDIENCE, claimsSet.getAudience() != null ?
+                            claimsSet.getAudience() : StringUtils.EMPTY);
+                    entityInfo.put(AuditLogConstants.JWT_ID, claimsSet.getJWTID() != null ? claimsSet.getJWTID() :
+                            StringUtils.EMPTY);
                     entityInfo.put(AuditLogConstants.ISSUED_AT, claimsSet.getIssueTime().getTime());
                 }
             }
         } catch (ParseException ignore) {
+            // Ignoring the exception as the JWT validation is already handled in the Grant Handler
         }
         return entityInfo;
     }
@@ -144,9 +147,10 @@ public class APIMTokenExchangeAuditLogger extends AbstractOAuthEventInterceptor 
         entityInfo.put(AuditLogConstants.REQUESTED_TOKEN_TYPE, getRequestedTokenType(requestParams));
         if (isJWT(requestParams.get(AuditLogConstants.SUBJECT_TOKEN_TYPE), requestParams
                 .get(AuditLogConstants.SUBJECT_TOKEN))) {
-            entityInfo.put("subject_token_info", getJWTClaims(requestParams.get(AuditLogConstants.SUBJECT_TOKEN)));
+            entityInfo.put(AuditLogConstants.SUBJECT_TOKEN_INFO,
+                    getJWTClaims(requestParams.get(AuditLogConstants.SUBJECT_TOKEN)));
         }
-        entityInfo.put("issued_token_info", getJWTClaims(tokenRespDTO.getAccessToken()));
+        entityInfo.put(AuditLogConstants.ISSUED_TOKEN_INFO, getJWTClaims(tokenRespDTO.getAccessToken()));
         return entityInfo;
     }
 }

--- a/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/APIMTokenExchangeAuditLogger.java
+++ b/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/APIMTokenExchangeAuditLogger.java
@@ -1,0 +1,152 @@
+/*
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.is.notification;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.logging.Log;
+import org.json.JSONObject;
+import org.wso2.carbon.identity.oauth.event.AbstractOAuthEventInterceptor;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
+import org.wso2.carbon.identity.oauth2.model.RequestParameter;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.is.notification.NotificationConstants.AuditLogConstants;
+
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.wso2.carbon.CarbonConstants.AUDIT_LOG;
+
+/**
+ * APIM Token Exchange Audit Logger Interceptor Implementation
+ */
+public class APIMTokenExchangeAuditLogger extends AbstractOAuthEventInterceptor {
+
+    private static final Log audit = AUDIT_LOG;
+
+    public APIMTokenExchangeAuditLogger() {
+
+        super.init(initConfig);
+    }
+
+    /**
+     * Audit Logs the exchanged token information for token exchange flow in success scenario
+     *
+     * @param tokenReqDTO  Token Request DTO
+     * @param tokenRespDTO Token Response DTO
+     * @param tokReqMsgCtx Oauth Token Request Message Context
+     * @param params       HTTP Request Parameters
+     */
+    @Override
+    public void onPostTokenIssue(OAuth2AccessTokenReqDTO tokenReqDTO, OAuth2AccessTokenRespDTO tokenRespDTO,
+                                 OAuthTokenReqMessageContext tokReqMsgCtx, Map<String, Object> params) {
+
+        if (!isTokenExchangeGrant(tokenReqDTO)) {
+            return;
+        }
+
+        if (isTokenRequestSuccessful(tokenRespDTO)) {
+            JSONObject entityInfo = constructEntityInfo(tokenReqDTO, tokenRespDTO);
+            logAuditMessage(entityInfo, tokReqMsgCtx.getAuthorizedUser().getUserName());
+        }
+    }
+
+    private static void logAuditMessage(JSONObject entityInfo, String performedBy) {
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("typ", AuditLogConstants.TOKEN_GENERATION);
+        jsonObject.put("action", AuditLogConstants.TOKEN_EXCHANGE);
+        jsonObject.put("performedBy", performedBy);
+        jsonObject.put("info", entityInfo);
+        audit.info(StringEscapeUtils.unescapeJava(jsonObject.toString()));
+    }
+
+    private static Map<String, String> getRequestParams(RequestParameter[] params) {
+
+        return Arrays.stream(params).collect(Collectors.toMap(RequestParameter::getKey,
+                requestParam -> requestParam.getValue()[0]));
+    }
+
+    private static JSONObject getJWTClaims(String jwtToken) {
+
+        JSONObject entityInfo = new JSONObject();
+        try {
+            if (StringUtils.isNotEmpty(jwtToken)) {
+                SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+                if (signedJWT.getJWTClaimsSet() != null) {
+                    JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+                    entityInfo.put(AuditLogConstants.ISSUER, claimsSet.getIssuer());
+                    entityInfo.put(AuditLogConstants.AUDIENCE, claimsSet.getAudience());
+                    entityInfo.put(AuditLogConstants.JWT_ID, claimsSet.getJWTID());
+                    entityInfo.put(AuditLogConstants.ISSUED_AT, claimsSet.getIssueTime().getTime());
+                }
+            }
+        } catch (ParseException ignore) {
+        }
+        return entityInfo;
+    }
+
+    private static boolean isJWT(String subjectTokenType, String subjectToken) {
+
+        return AuditLogConstants.JWT_TOKEN_TYPE.equals(subjectTokenType) ||
+                (AuditLogConstants.ACCESS_TOKEN_TYPE.equals(subjectTokenType)
+                        && OAuth2Util.isJWT(subjectToken));
+    }
+
+    private static boolean isTokenExchangeGrant(OAuth2AccessTokenReqDTO tokenReqDTO) {
+
+        return AuditLogConstants.TOKEN_EXCHANGE_GRANT.equals(tokenReqDTO.getGrantType());
+    }
+
+    private boolean isTokenRequestSuccessful(OAuth2AccessTokenRespDTO tokenRespDTO) {
+
+        return !tokenRespDTO.isError();
+    }
+
+    private static String getRequestedTokenType(Map<String, String> requestParams) {
+
+        if (requestParams.get(AuditLogConstants.REQUESTED_TOKEN_TYPE) != null) {
+            return requestParams.get(AuditLogConstants.REQUESTED_TOKEN_TYPE);
+        } else {
+            return AuditLogConstants.JWT_TOKEN_TYPE;
+        }
+    }
+
+    private static JSONObject constructEntityInfo(OAuth2AccessTokenReqDTO tokenReqDTO,
+                                                  OAuth2AccessTokenRespDTO tokenRespDTO) {
+
+        JSONObject entityInfo = new JSONObject();
+        Map<String, String> requestParams = getRequestParams(tokenReqDTO.getRequestParameters());
+        entityInfo.put(AuditLogConstants.CLIENT_ID, tokenReqDTO.getClientId());
+        entityInfo.put(AuditLogConstants.GRANT_TYPE, tokenReqDTO.getGrantType());
+        entityInfo.put(AuditLogConstants.REQUESTED_TOKEN_TYPE, getRequestedTokenType(requestParams));
+        if (isJWT(requestParams.get(AuditLogConstants.SUBJECT_TOKEN_TYPE), requestParams
+                .get(AuditLogConstants.SUBJECT_TOKEN))) {
+            entityInfo.put("subject_token_info", getJWTClaims(requestParams.get(AuditLogConstants.SUBJECT_TOKEN)));
+        }
+        entityInfo.put("issued_token_info", getJWTClaims(tokenRespDTO.getAccessToken()));
+        return entityInfo;
+    }
+}

--- a/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/NotificationConstants.java
+++ b/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/NotificationConstants.java
@@ -35,4 +35,25 @@ public class NotificationConstants {
     public static final String ADMIN_USER_NAME_SYSTEM_PROPERTY = "admin.username";
     public static final String ADMIN_PASSWORD_SYSTEM_PROPERTY = "admin.password";
     public static final String CARBON_HOME_SYSTEM_PROPERTY = "carbon.home";
+
+    /**
+     * Audit Log Constants
+     */
+    static class AuditLogConstants {
+
+        static final String ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+        static final String AUDIENCE = "audience";
+        static final String CLIENT_ID = "client_id";
+        static final String GRANT_TYPE = "grant_type";
+        static final String ISSUER = "issuer";
+        static final String ISSUED_AT = "iat";
+        static final String JWT_ID = "jti";
+        static final String JWT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
+        static final String REQUESTED_TOKEN_TYPE = "requested_token_type";
+        static final String SUBJECT_TOKEN = "subject_token";
+        static final String SUBJECT_TOKEN_TYPE = "subject_token_type";
+        static final String TOKEN_EXCHANGE = "Token Exchange";
+        static final String TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
+        static final String TOKEN_GENERATION = "Token Generation";
+    }
 }

--- a/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/NotificationConstants.java
+++ b/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/NotificationConstants.java
@@ -55,5 +55,7 @@ public class NotificationConstants {
         static final String TOKEN_EXCHANGE = "Token Exchange";
         static final String TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
         static final String TOKEN_GENERATION = "Token Generation";
+        static final String SUBJECT_TOKEN_INFO = "subject_token_info";
+        static final String ISSUED_TOKEN_INFO = "issued_token_info";
     }
 }

--- a/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/internal/NotificationServiceComponent.java
+++ b/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/internal/NotificationServiceComponent.java
@@ -26,6 +26,7 @@ public class NotificationServiceComponent {
 
     private static final Log log = LogFactory.getLog(NotificationServiceComponent.class);
     ServiceRegistration<OAuthEventInterceptor> serviceRegistration;
+    private ServiceRegistration<OAuthEventInterceptor> auditLoggerServiceRegistration;
 
     @Activate
     protected void activate(ComponentContext componentContext) throws Exception {
@@ -33,7 +34,7 @@ public class NotificationServiceComponent {
         BundleContext bundleContext = componentContext.getBundleContext();
         serviceRegistration =
                 bundleContext.registerService(OAuthEventInterceptor.class, new ApimOauthEventInterceptor(), null);
-        serviceRegistration =
+        auditLoggerServiceRegistration =
                 bundleContext.registerService(OAuthEventInterceptor.class, new APIMTokenExchangeAuditLogger(), null);
     }
 
@@ -91,6 +92,9 @@ public class NotificationServiceComponent {
 
         if (serviceRegistration != null) {
             serviceRegistration.unregister();
+        }
+        if (auditLoggerServiceRegistration != null) {
+            auditLoggerServiceRegistration.unregister();
         }
         if (log.isDebugEnabled()) {
             log.info("Oauth Listeners disabled");

--- a/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/internal/NotificationServiceComponent.java
+++ b/components/wso2is.notification.event.handlers/src/main/java/org/wso2/is/notification/internal/NotificationServiceComponent.java
@@ -15,6 +15,7 @@ import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.oauth.event.OAuthEventInterceptor;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
+import org.wso2.is.notification.APIMTokenExchangeAuditLogger;
 import org.wso2.is.notification.ApimOauthEventInterceptor;
 
 /**
@@ -32,6 +33,8 @@ public class NotificationServiceComponent {
         BundleContext bundleContext = componentContext.getBundleContext();
         serviceRegistration =
                 bundleContext.registerService(OAuthEventInterceptor.class, new ApimOauthEventInterceptor(), null);
+        serviceRegistration =
+                bundleContext.registerService(OAuthEventInterceptor.class, new APIMTokenExchangeAuditLogger(), null);
     }
 
     @Reference(


### PR DESCRIPTION
## Purpose

Related issue - https://github.com/wso2-enterprise/choreo/issues/6118

Adding the audit logs related to token exchange flow. Example:

```
TID: [-1234] [2021-07-06 20:23:53,368]  INFO {AUDIT_LOG} - {"performedBy":"0oav2olxw1fuy6pG05d6","action":"Token Exchange","typ":"Token Generation","info":{"issued_token_info":{"audience":["xxxx"],"iat":1625583233000,"issuer":"https://localhost:9443/oauth2/token","jti":"9effe08f-dc07-49a3-b4d4-96807ea3da1d"},"grant_type":"urn:ietf:params:oauth:grant-type:token-exchange","subject_token_info":{"audience":["xxxx"],"iat":1625582113000,"issuer":"https://{idp-domain}/oauth2/token","jti":"x7545VNWAhib6ndgH_oxJmNbN1DfrU3h0zlAf9v1cQ"},"client_id":"rq8oveYM22fsVRMtjwNV8w1NG7ca","requested_token_type":"urn:ietf:params:oauth:token-type:jwt"}}
```