### PR TITLE
Add support to display application name in consent page

### DIFF
--- a/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/RegistrationRequestDTO.java
@@ -21,6 +21,7 @@ public class RegistrationRequestDTO   {
     private String clientId = null;
     private String clientSecret = null;
     private List<String> grantTypes = new ArrayList<>();
+    private String applicationDisplayName = null;
     private String applicationType = null;
     private String tokenTypeExtension = null;
     private String extApplicationOwner = null;
@@ -125,6 +126,23 @@ public class RegistrationRequestDTO   {
   }
   public void setGrantTypes(List<String> grantTypes) {
     this.grantTypes = grantTypes;
+  }
+
+  /**
+   **/
+  public RegistrationRequestDTO applicationDisplayName(String applicationDisplayName) {
+    this.applicationDisplayName = applicationDisplayName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("application_display_name")
+  public String getApplicationDisplayName() {
+    return applicationDisplayName;
+  }
+  public void setApplicationDisplayName(String applicationDisplayName) {
+    this.applicationDisplayName = applicationDisplayName;
   }
 
   /**
@@ -448,6 +466,7 @@ public class RegistrationRequestDTO   {
         Objects.equals(clientId, registrationRequest.clientId) &&
         Objects.equals(clientSecret, registrationRequest.clientSecret) &&
         Objects.equals(grantTypes, registrationRequest.grantTypes) &&
+        Objects.equals(applicationDisplayName, registrationRequest.applicationDisplayName) &&
         Objects.equals(applicationType, registrationRequest.applicationType) &&
         Objects.equals(tokenTypeExtension, registrationRequest.tokenTypeExtension) &&
         Objects.equals(extApplicationOwner, registrationRequest.extApplicationOwner) &&
@@ -470,7 +489,7 @@ public class RegistrationRequestDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationType, tokenTypeExtension, extApplicationOwner, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, jwksUri, url, extParamClientId, extParamClientSecret, contacts, postLogoutRedirectUris, requestUris, responseTypes, extParamSpTemplate, backchannelLogoutUri, backchannelLogoutSessionRequired);
+    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationDisplayName, applicationType, tokenTypeExtension, extApplicationOwner, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, jwksUri, url, extParamClientId, extParamClientSecret, contacts, postLogoutRedirectUris, requestUris, responseTypes, extParamSpTemplate, backchannelLogoutUri, backchannelLogoutSessionRequired);
   }
 
   @Override
@@ -483,6 +502,7 @@ public class RegistrationRequestDTO   {
     sb.append("    clientId: ").append(toIndentedString(clientId)).append("\n");
     sb.append("    clientSecret: ").append(toIndentedString(clientSecret)).append("\n");
     sb.append("    grantTypes: ").append(toIndentedString(grantTypes)).append("\n");
+    sb.append("    applicationDisplayName: ").append(toIndentedString(applicationDisplayName)).append("\n");
     sb.append("    applicationType: ").append(toIndentedString(applicationType)).append("\n");
     sb.append("    tokenTypeExtension: ").append(toIndentedString(tokenTypeExtension)).append("\n");
     sb.append("    extApplicationOwner: ").append(toIndentedString(extApplicationOwner)).append("\n");

--- a/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/UpdateRequestDTO.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/UpdateRequestDTO.java
@@ -21,6 +21,7 @@ public class UpdateRequestDTO   {
     private String clientId = null;
     private String clientSecret = null;
     private List<String> grantTypes = new ArrayList<>();
+    private String applicationDisplayName = null;
     private String tokenTypeExtension = null;
     private String extApplicationOwner = null;
     private String backchannelLogoutUri = null;
@@ -113,6 +114,23 @@ public class UpdateRequestDTO   {
   }
   public void setGrantTypes(List<String> grantTypes) {
     this.grantTypes = grantTypes;
+  }
+
+  /**
+   **/
+  public UpdateRequestDTO applicationDisplayName(String applicationDisplayName) {
+    this.applicationDisplayName = applicationDisplayName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("application_display_name")
+  public String getApplicationDisplayName() {
+    return applicationDisplayName;
+  }
+  public void setApplicationDisplayName(String applicationDisplayName) {
+    this.applicationDisplayName = applicationDisplayName;
   }
 
   /**
@@ -266,6 +284,7 @@ public class UpdateRequestDTO   {
         Objects.equals(clientId, updateRequest.clientId) &&
         Objects.equals(clientSecret, updateRequest.clientSecret) &&
         Objects.equals(grantTypes, updateRequest.grantTypes) &&
+        Objects.equals(applicationDisplayName, updateRequest.applicationDisplayName) &&
         Objects.equals(tokenTypeExtension, updateRequest.tokenTypeExtension) &&
         Objects.equals(extApplicationOwner, updateRequest.extApplicationOwner) &&
         Objects.equals(backchannelLogoutUri, updateRequest.backchannelLogoutUri) &&
@@ -278,7 +297,7 @@ public class UpdateRequestDTO   {
 
   @Override
   public int hashCode() {
-    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, tokenTypeExtension, extApplicationOwner, backchannelLogoutUri, backchannelLogoutSessionRequired, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime);
+    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationDisplayName, tokenTypeExtension, extApplicationOwner, backchannelLogoutUri, backchannelLogoutSessionRequired, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime);
   }
 
   @Override
@@ -291,6 +310,7 @@ public class UpdateRequestDTO   {
     sb.append("    clientId: ").append(toIndentedString(clientId)).append("\n");
     sb.append("    clientSecret: ").append(toIndentedString(clientSecret)).append("\n");
     sb.append("    grantTypes: ").append(toIndentedString(grantTypes)).append("\n");
+    sb.append("    applicationDisplayName: ").append(toIndentedString(applicationDisplayName)).append("\n");
     sb.append("    tokenTypeExtension: ").append(toIndentedString(tokenTypeExtension)).append("\n");
     sb.append("    extApplicationOwner: ").append(toIndentedString(extApplicationOwner)).append("\n");
     sb.append("    backchannelLogoutUri: ").append(toIndentedString(backchannelLogoutUri)).append("\n");

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationRegistrationRequest.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationRegistrationRequest.java
@@ -34,6 +34,7 @@ public class ExtendedApplicationRegistrationRequest extends ApplicationRegistrat
     private Long userAccessTokenLifeTime;
     private Long refreshTokenLifeTime;
     private Long idTokenLifeTime;
+    private String applicationDisplayName;
 
     public Long getApplicationAccessTokenLifeTime() {
 
@@ -87,6 +88,20 @@ public class ExtendedApplicationRegistrationRequest extends ApplicationRegistrat
     public void setApplicationOwner(String applicationOwner) {
 
         this.applicationOwner = applicationOwner;
+    }
+
+    /**
+     *
+     * @return applicationDisplayName
+     */
+    public String getApplicationDisplayName() {
+
+        return applicationDisplayName;
+    }
+
+    public void setApplicationDisplayName(String applicationDisplayName) {
+
+        this.applicationDisplayName = applicationDisplayName;
     }
 
 }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationUpdateRequest.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationUpdateRequest.java
@@ -1,6 +1,21 @@
-/**
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.wso2.is.key.manager.operations.endpoint.dcr.bean;
 
 import org.wso2.carbon.identity.oauth.dcr.bean.ApplicationUpdateRequest;
@@ -16,6 +31,7 @@ public class ExtendedApplicationUpdateRequest extends ApplicationUpdateRequest {
     private Long userAccessTokenLifeTime;
     private Long refreshTokenLifeTime;
     private Long idTokenLifeTime;
+    private String applicationDisplayName;
 
     public void setApplicationAccessTokenLifeTime(Long applicationAccessTokenLifeTime) {
 
@@ -56,4 +72,15 @@ public class ExtendedApplicationUpdateRequest extends ApplicationUpdateRequest {
 
         return idTokenLifeTime;
     }
+
+    public void setApplicationDisplayName(String applicationDisplayName) {
+
+        this.applicationDisplayName = applicationDisplayName;
+    }
+
+    public String getApplicationDisplayName() {
+
+        return applicationDisplayName;
+    }
+
 }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -109,7 +109,9 @@ public class DCRMService {
         sp.setSaasApp(true);
 
         // Set service provider properties
-        sp.setSpProperties(getServiceProviderPropertyList(updateRequest.getApplicationDisplayName()));
+        ServiceProviderProperty[] spProperties = getServiceProviderPropertyList(
+                updateRequest.getApplicationDisplayName());
+        sp.setSpProperties(spProperties);
 
         if (StringUtils.isNotEmpty(clientName)) {
             // Regex validation of the application name.
@@ -389,8 +391,9 @@ public class DCRMService {
         }
 
         // Set service provider properties
-        serviceProvider.setSpProperties(
-                getServiceProviderPropertyList(registrationRequest.getApplicationDisplayName()));
+        ServiceProviderProperty[] spProperties = getServiceProviderPropertyList(
+                registrationRequest.getApplicationDisplayName());
+        serviceProvider.setSpProperties(spProperties);
 
         try {
             updateServiceProviderWithOAuthAppDetails(serviceProvider, createdApp, applicationOwner, tenantDomain);

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -108,12 +108,8 @@ public class DCRMService {
         // We are setting this to true in order to support cross tenant subscriptions.
         sp.setSaasApp(true);
 
-        // Set application name as the display name in the consent page
-        ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
-        serviceProviderProperty.setName(APP_DISPLAY_NAME);
-        serviceProviderProperty.setValue(updateRequest.getApplicationDisplayName());
-        ServiceProviderProperty[] serviceProviderProperties = { serviceProviderProperty };
-        sp.setSpProperties(serviceProviderProperties);
+        // Set service provider properties
+        sp.setSpProperties(getServiceProviderPropertyList(updateRequest.getApplicationDisplayName()));
 
         if (StringUtils.isNotEmpty(clientName)) {
             // Regex validation of the application name.
@@ -170,6 +166,23 @@ public class DCRMService {
         }
 
         return buildResponse(getApplicationById(clientId));
+    }
+
+    /**
+     * Get service provider property list
+     *
+     * @param applicationDisplayName Display name of the application
+     * @return ServiceProviderProperty[]
+     */
+    public ServiceProviderProperty[] getServiceProviderPropertyList(String applicationDisplayName) {
+
+        // Set application display name. This property is used when displaying the app name within the consent page.
+        ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
+        serviceProviderProperty.setName(APP_DISPLAY_NAME);
+        serviceProviderProperty.setValue(applicationDisplayName);
+        ServiceProviderProperty[] serviceProviderProperties = { serviceProviderProperty };
+
+        return serviceProviderProperties;
     }
 
     /**
@@ -375,12 +388,9 @@ public class DCRMService {
             throw ex;
         }
 
-        // Set application name as the display name in the consent page
-        ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
-        serviceProviderProperty.setName(APP_DISPLAY_NAME);
-        serviceProviderProperty.setValue(registrationRequest.getApplicationDisplayName());
-        ServiceProviderProperty[] serviceProviderProperties = { serviceProviderProperty };
-        serviceProvider.setSpProperties(serviceProviderProperties);
+        // Set service provider properties
+        serviceProvider.setSpProperties(
+                getServiceProviderPropertyList(registrationRequest.getApplicationDisplayName()));
 
         try {
             updateServiceProviderWithOAuthAppDetails(serviceProvider, createdApp, applicationOwner, tenantDomain);

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
@@ -65,6 +66,7 @@ public class DCRMService {
     private static final String AUTH_TYPE_OAUTH_2 = "oauth2";
     private static final String OAUTH_VERSION = "OAuth-2.0";
     private static final String GRANT_TYPE_SEPARATOR = " ";
+    private static final String APP_DISPLAY_NAME = "DisplayName";
     private static Pattern clientIdRegexPattern = null;
 
     public DCRMService() {
@@ -105,6 +107,14 @@ public class DCRMService {
         ServiceProvider sp = getServiceProvider(appDTO.getApplicationName(), tenantDomain);
         // We are setting this to true in order to support cross tenant subscriptions.
         sp.setSaasApp(true);
+
+        // Set application name as the display name in the consent page
+        ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
+        serviceProviderProperty.setName(APP_DISPLAY_NAME);
+        serviceProviderProperty.setValue(updateRequest.getApplicationDisplayName());
+        ServiceProviderProperty[] serviceProviderProperties = {serviceProviderProperty};
+        sp.setSpProperties(serviceProviderProperties);
+
         if (StringUtils.isNotEmpty(clientName)) {
             // Regex validation of the application name.
             if (!DCRMUtils.isRegexValidated(clientName)) {
@@ -364,6 +374,13 @@ public class DCRMService {
             deleteServiceProvider(spName, tenantDomain, applicationOwner);
             throw ex;
         }
+
+        // Set application name as the display name in the consent page
+        ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
+        serviceProviderProperty.setName(APP_DISPLAY_NAME);
+        serviceProviderProperty.setValue(registrationRequest.getApplicationDisplayName());
+        ServiceProviderProperty[] serviceProviderProperties = {serviceProviderProperty};
+        serviceProvider.setSpProperties(serviceProviderProperties);
 
         try {
             updateServiceProviderWithOAuthAppDetails(serviceProvider, createdApp, applicationOwner, tenantDomain);

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -112,7 +112,7 @@ public class DCRMService {
         ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
         serviceProviderProperty.setName(APP_DISPLAY_NAME);
         serviceProviderProperty.setValue(updateRequest.getApplicationDisplayName());
-        ServiceProviderProperty[] serviceProviderProperties = {serviceProviderProperty};
+        ServiceProviderProperty[] serviceProviderProperties = { serviceProviderProperty };
         sp.setSpProperties(serviceProviderProperties);
 
         if (StringUtils.isNotEmpty(clientName)) {
@@ -379,7 +379,7 @@ public class DCRMService {
         ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
         serviceProviderProperty.setName(APP_DISPLAY_NAME);
         serviceProviderProperty.setValue(registrationRequest.getApplicationDisplayName());
-        ServiceProviderProperty[] serviceProviderProperties = {serviceProviderProperty};
+        ServiceProviderProperty[] serviceProviderProperties = { serviceProviderProperty };
         serviceProvider.setSpProperties(serviceProviderProperties);
 
         try {

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
@@ -67,6 +67,7 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         appRegistrationRequest.setUserAccessTokenLifeTime(registrationRequestDTO.getExtUserTokenLifetime());
         appRegistrationRequest.setRefreshTokenLifeTime(registrationRequestDTO.getExtRefreshTokenLifetime());
         appRegistrationRequest.setIdTokenLifeTime(registrationRequestDTO.getExtIdTokenLifetime());
+        appRegistrationRequest.setApplicationDisplayName(registrationRequestDTO.getApplicationDisplayName());
         return appRegistrationRequest;
 
     }
@@ -84,7 +85,7 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         applicationUpdateRequest.setUserAccessTokenLifeTime(updateRequestDTO.getExtUserTokenLifetime());
         applicationUpdateRequest.setRefreshTokenLifeTime(updateRequestDTO.getExtRefreshTokenLifetime());
         applicationUpdateRequest.setIdTokenLifeTime(updateRequestDTO.getExtIdTokenLifetime());
-
+        applicationUpdateRequest.setApplicationDisplayName(updateRequestDTO.getApplicationDisplayName());
         return applicationUpdateRequest;
 
     }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/resources/keymanager-operations.yaml
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/resources/keymanager-operations.yaml
@@ -459,6 +459,8 @@ definitions:
         type: array
         items:
           type: string
+      application_display_name:
+        type: string
       application_type:
         type: string
       token_type_extension:
@@ -528,6 +530,8 @@ definitions:
           type: array
           items:
             type: string
+        application_display_name:
+          type: string
         token_type_extension:
           type: string
         ext_application_owner:


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/11620

This PR adds the support to display application name in consent page. With the proposed changes, we attach the display name property to the service provider. This change is reflected for both, application registration and application update.

## Related PRs

- https://github.com/wso2/carbon-apimgt/pull/10800
- https://github.com/wso2/carbon-identity-framework/pull/3740
- https://github.com/wso2/product-apim/pull/11716