### PR TITLE
Move override.sp.name system property functionality to DCRMService

### DIFF
--- a/components/wso2is.key.manager.operations.endpoint/pom.xml
+++ b/components/wso2is.key.manager.operations.endpoint/pom.xml
@@ -183,5 +183,10 @@
             <artifactId>org.wso2.carbon.claim.mgt</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
@@ -17,8 +17,10 @@
  */
 package org.wso2.is.key.manager.operations.endpoint.dcr.util;
 
+import com.google.gson.Gson;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.oauth.OAuthAdminService;
 import org.wso2.carbon.identity.oauth.dcr.DCRMConstants;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMException;
@@ -226,4 +228,17 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         }
     }
 
+
+    /**
+     * Create a deep copy of the input Service Provider.
+     *
+     * @param serviceProvider Service Provider.
+     * @return Clone of serviceProvider.
+     */
+    public static ServiceProvider cloneServiceProvider(ServiceProvider serviceProvider) {
+
+        Gson gson = new Gson();
+        ServiceProvider clonedServiceProvider = gson.fromJson(gson.toJson(serviceProvider), ServiceProvider.class);
+        return clonedServiceProvider;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,11 @@
                 <version>${project.version}</version>
                 <type>war</type>
             </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${com.google.code.gson.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -380,5 +385,6 @@
         <io.swagger.codegen.version>2.4.11</io.swagger.codegen.version>
         <identity.auth.rest.version>1.4.0</identity.auth.rest.version>
         <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
+        <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
     </properties>
 </project>


### PR DESCRIPTION
fix wso2/product-apim#11604
related pr wso2-support/carbon-apimgt#3770

This PR contains the same fix done for IAM DCR service with wso2-support/identity-inbound-auth-oauth@e1a1163 to deep copy the received SP object and call the updateApplication admin service with it. In addition, this includes the fix for wso2/product-apim#9455