### PR TITLE
Third-party dependency upgrade

### DIFF
--- a/components/wso2is.key.manager.operations.endpoint/pom.xml
+++ b/components/wso2is.key.manager.operations.endpoint/pom.xml
@@ -127,6 +127,10 @@
             <artifactId>swagger-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
@@ -207,6 +211,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,11 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax.validation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
@@ -408,6 +413,7 @@
         <spring-web.version>5.1.13.RELEASE</spring-web.version>
         <json.orbit.version>3.0.0.wso2v1</json.orbit.version>
         <swagger-jaxrs.version>1.6.1</swagger-jaxrs.version>
+        <javax.validation-api>2.0.1.Final</javax.validation-api>
         <javax.ws.rs.version>2.1.1</javax.ws.rs.version>
         <fasterxml.jackson.version>2.10.3</fasterxml.jackson.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/1017
Related PR - https://github.com/wso2-support/apim-km-wso2is/pull/83
validation-api has been updated from 1.1.0.Final to 2.0.1.Final  from this PR

The following component will be updated from this PR

- ./repository/deployment/server/webapps/keymanager-operations/WEB-INF/lib/validation-api-1.1.0.Final.jar