### PR TITLE
Upgrading carbon-apimgt, kernel and identity dependencies to support APIM 4.2.0 and IS 6.0.0

### DIFF
--- a/components/wso2is.key.manager.core/pom.xml
+++ b/components/wso2is.key.manager.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>wso2is.auth.client</artifactId>
         <groupId>org.wso2.km.ext.wso2is</groupId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/wso2is.key.manager.operations.endpoint/pom.xml
+++ b/components/wso2is.key.manager.operations.endpoint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.km.ext.wso2is</groupId>
         <artifactId>wso2is.auth.client</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/wso2is.key.manager/pom.xml
+++ b/components/wso2is.key.manager/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.km.ext.wso2is</groupId>
         <artifactId>wso2is.auth.client</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>wso2is.key.manager</artifactId>

--- a/components/wso2is.notification.event.handlers/pom.xml
+++ b/components/wso2is.notification.event.handlers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>wso2is.auth.client</artifactId>
         <groupId>org.wso2.km.ext.wso2is</groupId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>wso2is.auth.client</artifactId>
         <groupId>org.wso2.km.ext.wso2is</groupId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/wso2is.key.manager.feature/pom.xml
+++ b/features/wso2is.key.manager.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.km.ext.wso2is</groupId>
         <artifactId>wso2is.auth.client</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/wso2is.key.manager.notification.feature/pom.xml
+++ b/features/wso2is.key.manager.notification.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.km.ext.wso2is</groupId>
         <artifactId>wso2is.auth.client</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/wso2is.key.manager.operations.endpoint.feature/pom.xml
+++ b/features/wso2is.key.manager.operations.endpoint.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.km.ext.wso2is</groupId>
         <artifactId>wso2is.auth.client</artifactId>
-        <version>1.5.5-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -400,8 +400,8 @@
     <properties>
         <common.codec.version>1.15</common.codec.version>
         <carbon.apimgt.version>6.7.206</carbon.apimgt.version>
-        <carbon.identity.version>5.18.238</carbon.identity.version>
-        <carbon.identity-oauth2-grant-jwt.version>1.0.26</carbon.identity-oauth2-grant-jwt.version>
+        <carbon.identity.version>5.23.8</carbon.identity.version>
+        <carbon.identity-oauth2-grant-jwt.version>2.0.4</carbon.identity-oauth2-grant-jwt.version>
         <json.simple.version>1.1</json.simple.version>
         <json-simple.wso2.version>1.1.wso2v1</json-simple.wso2.version>
         <cxf.version>3.3.6</cxf.version>
@@ -410,15 +410,15 @@
         <swagger-jaxrs.version>1.6.1</swagger-jaxrs.version>
         <javax.ws.rs.version>2.1.1</javax.ws.rs.version>
         <fasterxml.jackson.version>2.10.3</fasterxml.jackson.version>
-        <carbon.kernel.version>4.6.0</carbon.kernel.version>
+        <carbon.kernel.version>4.7.1</carbon.kernel.version>
         <fasterxml.jackson.databind.version>2.10.3</fasterxml.jackson.databind.version>
         <gson.version>2.1</gson.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <project.version>1.0.0-SNAPSHOT</project.version>
         <imp.package.version.osgi.framework>[1.6.0, 2.0.0)</imp.package.version.osgi.framework>
         <imp.package.version.osgi.service>[1.2.0,1.3.0)</imp.package.version.osgi.service>
-        <carbon.identity-inbound-auth-oauth.version>6.4.168</carbon.identity-inbound-auth-oauth.version>
-        <carbon.identity-data-publisher-application-authentication.version>5.3.19
+        <carbon.identity-inbound-auth-oauth.version>6.8.0</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-data-publisher-application-authentication.version>5.4.4
         </carbon.identity-data-publisher-application-authentication.version>
         <http.client.version>4.3.6.wso2v1</http.client.version>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
@@ -429,7 +429,7 @@
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <version.checkstyle>8.34</version.checkstyle>
         <io.swagger.codegen.version>2.4.11</io.swagger.codegen.version>
-        <identity.auth.rest.version>1.4.0</identity.auth.rest.version>
+        <identity.auth.rest.version>1.6.1</identity.auth.rest.version>
         <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
         <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.km.ext.wso2is</groupId>
     <artifactId>wso2is.auth.client</artifactId>
-    <version>1.5.5-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
     </scm>
     <properties>
         <common.codec.version>1.15</common.codec.version>
-        <carbon.apimgt.version>6.7.206</carbon.apimgt.version>
+        <carbon.apimgt.version>9.27.0</carbon.apimgt.version>
         <carbon.identity.version>5.23.8</carbon.identity.version>
         <carbon.identity-oauth2-grant-jwt.version>2.0.4</carbon.identity-oauth2-grant-jwt.version>
         <json.simple.version>1.1</json.simple.version>


### PR DESCRIPTION
## Purpose
Upgrading carbon-apimgt, kernel and identity dependencies to support APIM 4.2.0 and IS 6.0.0

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11628