### PR TITLE
Introduce `Use as Application Owner` New Property to WSO2 IS Connector Configuration

### DIFF
--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -386,7 +386,11 @@ public class DCRMService {
 
         String applicationOwner = registrationRequest.getApplicationOwner();
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(applicationOwner);
+        if (!StringUtils.isEmpty(applicationOwner)) {
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(applicationOwner);
+        } else {
+            applicationOwner = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+        }
 
         String spName = registrationRequest.getClientName();
         String templateName = registrationRequest.getSpTemplateName();

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -386,11 +386,7 @@ public class DCRMService {
 
         String applicationOwner = registrationRequest.getApplicationOwner();
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        if (!StringUtils.isEmpty(applicationOwner)) {
-            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(applicationOwner);
-        } else {
-            applicationOwner = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-        }
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(applicationOwner);
 
         String spName = registrationRequest.getClientName();
         String templateName = registrationRequest.getSpTemplateName();

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
@@ -60,8 +60,8 @@ public class WSO2ISConnectorConfiguration extends DefaultKeyManagerConnectorConf
                 .add(new ConfigurationDto("Password", "Password", "input",
                         "Password of Admin user", "", true, true, Collections.emptyList(), false));
         configurationDtoList.add(new ConfigurationDto(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_NAME,
-                WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL, "select", WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL, "",
-                false, false, Collections.singletonList(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_VALUE), false));
+                WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL, "checkbox", WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL,
+                "", false, false, Collections.singletonList(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_VALUE), false));
         configurationDtoList.addAll(super.getConnectionConfigurations());
         return configurationDtoList;
     }

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
@@ -59,6 +59,10 @@ public class WSO2ISConnectorConfiguration extends DefaultKeyManagerConnectorConf
         configurationDtoList
                 .add(new ConfigurationDto("Password", "Password", "input",
                         "Password of Admin user", "", true, true, Collections.emptyList(), false));
+        configurationDtoList.add(new ConfigurationDto("km_admin_as_app_owner",
+                "Enable admin user as the owner of created OAuth applications", "select",
+                "Enable admin user as the owner of created OAuth applications", "", false, false,
+                Collections.singletonList("Use as Application Owner"), false));
         configurationDtoList.addAll(super.getConnectionConfigurations());
         return configurationDtoList;
     }

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
@@ -59,10 +59,9 @@ public class WSO2ISConnectorConfiguration extends DefaultKeyManagerConnectorConf
         configurationDtoList
                 .add(new ConfigurationDto("Password", "Password", "input",
                         "Password of Admin user", "", true, true, Collections.emptyList(), false));
-        configurationDtoList.add(new ConfigurationDto("km_admin_as_app_owner",
-                "Enable admin user as the owner of created OAuth applications", "select",
-                "Enable admin user as the owner of created OAuth applications", "", false, false,
-                Collections.singletonList("Use as Application Owner"), false));
+        configurationDtoList.add(new ConfigurationDto(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_NAME,
+                WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL, "select", WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL, "",
+                false, false, Collections.singletonList(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_VALUE), false));
         configurationDtoList.addAll(super.getConnectionConfigurations());
         return configurationDtoList;
     }

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
@@ -24,10 +24,12 @@ public class WSO2ISConstants {
 
     public static final String WSO2IS_TYPE = "WSO2-IS";
     public static final String DISPLAY_NAME = "WSO2 Identity Server";
+    public static final String KEY_MANAGER_USERNAME = "Username";
+    public static final String OAUTH_CLIENT_USERNAME = "username";
     public static final String KM_ADMIN_AS_APP_OWNER_NAME = "km_admin_as_app_owner";
     public static final String KM_ADMIN_AS_APP_OWNER_LABEL =
             "Enable admin user as the owner of created OAuth applications";
-    public static final String KM_ADMIN_AS_APP_OWNER_VALUE = "Use as Application Owner";
+    public static final String KM_ADMIN_AS_APP_OWNER_VALUE = "Use as OAuth Application Owner";
 
     WSO2ISConstants() {
 

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
@@ -24,6 +24,9 @@ public class WSO2ISConstants {
 
     public static final String WSO2IS_TYPE = "WSO2-IS";
     public static final String DISPLAY_NAME = "WSO2 Identity Server";
+    public static final String KM_ADMIN_AS_APP_OWNER_NAME = "km_admin_as_app_owner";
+    public static final String KM_ADMIN_AS_APP_OWNER_LABEL = "Enable admin user as the owner of created OAuth applications";
+    public static final String KM_ADMIN_AS_APP_OWNER_VALUE = "Use as Application Owner";
 
     WSO2ISConstants() {
 

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
@@ -25,7 +25,8 @@ public class WSO2ISConstants {
     public static final String WSO2IS_TYPE = "WSO2-IS";
     public static final String DISPLAY_NAME = "WSO2 Identity Server";
     public static final String KM_ADMIN_AS_APP_OWNER_NAME = "km_admin_as_app_owner";
-    public static final String KM_ADMIN_AS_APP_OWNER_LABEL = "Enable admin user as the owner of created OAuth applications";
+    public static final String KM_ADMIN_AS_APP_OWNER_LABEL =
+            "Enable admin user as the owner of created OAuth applications";
     public static final String KM_ADMIN_AS_APP_OWNER_VALUE = "Use as Application Owner";
 
     WSO2ISConstants() {

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISOAuthClient.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISOAuthClient.java
@@ -39,6 +39,7 @@ public class WSO2ISOAuthClient extends AMDefaultKeyManagerImpl {
         return WSO2ISConstants.WSO2IS_TYPE;
     }
 
+    @Override
     public OAuthApplicationInfo createApplication(OAuthAppRequest oauthAppRequest) throws APIManagementException {
         if (useKmAdminAsAppOwner()) {
             overrideKMAdminAsAppOwnerProperties(oauthAppRequest);
@@ -54,6 +55,11 @@ public class WSO2ISOAuthClient extends AMDefaultKeyManagerImpl {
         return super.updateApplication(appInfoDTO);
     }
 
+    /**
+     * Check whether KM admin has to be used as the OAuth application owner
+     *
+     * @return whether KM admin has to be used as the OAuth application owner
+     */
     private boolean useKmAdminAsAppOwner() throws APIManagementException {
         boolean kmAdminAsAppOwner = false;
         Object kmAdminAsAppOwnerParameter = this.getKeyManagerConfiguration()
@@ -64,6 +70,10 @@ public class WSO2ISOAuthClient extends AMDefaultKeyManagerImpl {
         return kmAdminAsAppOwner;
     }
 
+    /**
+     * Override the OAuth app username with the KM admin username and tenant domain
+     * with the KM admin user's tenant domain
+     */
     private void overrideKMAdminAsAppOwnerProperties(OAuthAppRequest oauthAppRequest) {
         String kmAdminUsername = this.getConfigurationParamValue(WSO2ISConstants.KEY_MANAGER_USERNAME);
         OAuthApplicationInfo oAuthApplicationInfo = oauthAppRequest.getOAuthApplicationInfo();


### PR DESCRIPTION
## Purpose
- Introduce a new property named `Use as OAuth Application Owner` to WSO2 IS connector configuration. This property enables provided admin user as the owner of created OAuth applications.
- Related Issue: https://github.com/wso2/api-manager/issues/1821
- The new property will be displayed in the Admin portal UI when adding a Key Manager by selecting WSO2 Identity Server as the KM type as follows.
![Screenshot from 2023-06-08 11-47-17](https://github.com/wso2-extensions/apim-km-wso2is/assets/30455603/38bc22ef-11bb-4e42-a741-9d06a82969ef)

## Approach
- This property governs the value of the application owner sent in the DCR register request.
- If this property is selected, the application owner value will be admin user of WSO2 IS KM
- If this property is not selected, the application owner value will be the devportal user and that user will be used as the application owner. 