### PR TITLE
Resolves updating application properties for custom SP names

### DIFF
--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/service/DCRMService.java
@@ -108,7 +108,7 @@ public class DCRMService {
         String overrideSpNameProp = System.getProperty(OVERRIDE_SP_NAME);
         boolean overrideSpName = StringUtils.isEmpty(overrideSpNameProp) || Boolean.parseBoolean(overrideSpNameProp);
 
-        String clientName = updateRequest.getClientName();
+        String clientName = overrideSpName ? updateRequest.getClientName() : appDTO.getApplicationName();
 
         // Update Service Provider
         ServiceProvider sp = getServiceProvider(appDTO.getApplicationName(), tenantDomain);
@@ -131,9 +131,7 @@ public class DCRMService {
             // Need to create a deep clone, since modifying the fields of the original object,
             // will modify the cached SP object.
             ServiceProvider clonedSP = ExtendedDCRMUtils.cloneServiceProvider(sp);
-            if (overrideSpName) {
-                clonedSP.setApplicationName(clientName);
-            }
+            clonedSP.setApplicationName(clientName);
             updateServiceProvider(clonedSP, tenantDomain, applicationOwner);
         }
 


### PR DESCRIPTION
## Overview :
When -Doverride.sp.name is set to false in the pack and Service provider has custom names, application properties does not get updated. This PR resolves it.

When -Doverride.sp.name=false is added to api-manager.sh, Service Provider Name can be changed through carbon console and it will persist. If that property is not added and the service provider name is changed in the carbon console, as soon as the application is updated the service provider name will be overridden to the default name.

## Resolves : 
https://github.com/wso2/api-manager/issues/2060
