### PR TITLE
Add system property to avoid whitelisting apim rest apis scopes

### DIFF
--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponent.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponent.java
@@ -52,6 +52,7 @@ public class KeyManagerCoreServiceComponent {
 
     private static final Log log = LogFactory.getLog(KeyManagerCoreServiceComponent.class);
     private static final String RESTRICT_UNASSIGNED_SCOPES = "restrict.unassigned.scopes";
+    private static final String RESTRICT_APIM_REST_API_SCOPES = "restrict.apim.restapi.scopes";
 
     @Activate
     protected void activate(ComponentContext cxt) {
@@ -70,6 +71,9 @@ public class KeyManagerCoreServiceComponent {
 
             boolean restrictUnassignedScopes = Boolean.parseBoolean(System.getProperty(RESTRICT_UNASSIGNED_SCOPES));
             ServiceReferenceHolder.setRestrictUnassignedScopes(restrictUnassignedScopes);
+            boolean restrictApimRestApiScopes = Boolean.parseBoolean(System.getProperty(
+                    RESTRICT_APIM_REST_API_SCOPES));
+            ServiceReferenceHolder.setRestrictApimRestApiScopes(restrictProductRestApiScopes);
 
         } catch (Throwable e) {
             log.error(e.getMessage(), e);

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolder.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolder.java
@@ -35,6 +35,7 @@ public class ServiceReferenceHolder {
     private TenantRegistryLoader tenantRegistryLoader;
     private static ConfigurationContextService contextService;
     private static boolean restrictUnassignedScopes;
+    private static boolean restrictApimRestApiScopes;
 
     private ServiceReferenceHolder() {
 
@@ -85,5 +86,13 @@ public class ServiceReferenceHolder {
 
     public static void setRestrictUnassignedScopes(boolean restrictUnassignedScopes) {
         ServiceReferenceHolder.restrictUnassignedScopes = restrictUnassignedScopes;
+    }
+
+    public static boolean isRestrictApimRestApiScopes() {
+        return restrictApimRestApiScopes;
+    }
+
+    public static void setRestrictApimRestApiScopes(boolean restrictProductRestApiScopes) {
+        ServiceReferenceHolder.restrictApimRestApiScopes = restrictProductRestApiScopes;
     }
 }

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuer.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuer.java
@@ -298,12 +298,17 @@ public class RoleBasedScopesIssuer extends AbstractScopesIssuer implements Scope
         List<String> scopes = new ArrayList<>();
         if (oAuthAuthzReqMessageContext.getApprovedScope() != null) {
             requestedScopes = new ArrayList<>(Arrays.asList(oAuthAuthzReqMessageContext.getApprovedScope()));
-            for (String scope : requestedScopes) {
-                // If requestedScopes contains Product REST APIs (Publisher/DevPortal/Admin) scopes, just let them pass
-                // to the final scope list returned from RoleBasedScopeIssuer. This is because RoleBasedScopeIssuer is
-                // not responsible for validating Product REST API scopes. Those will be handled by SystemScopeIssuer.
-                if (checkForProductRestAPIScopes(scope)) {
-                    scopes.add(scope);
+            boolean isRestrictApimRestApiScopes = ServiceReferenceHolder.isRestrictApimRestApiScopes();
+            boolean isRestrictUnassignedScopes = ServiceReferenceHolder.isRestrictUnassignedScopes();
+            if (!(isRestrictUnassignedScopes && isRestrictApimRestApiScopes)) {
+                for (String scope : requestedScopes) {
+                    // If requestedScopes contains Product REST APIs (Publisher/DevPortal/Admin) scopes, just let
+                    // them pass to the final scope list returned from RoleBasedScopeIssuer. This is because
+                    // RoleBasedScopeIssuer is not responsible for validating Product REST API scopes. Those will be
+                    // handled by the SystemScopeIssuer.
+                    if (checkForProductRestAPIScopes(scope)) {
+                        scopes.add(scope);
+                    }
                 }
             }
             requestedScopes.removeAll(scopes);
@@ -366,12 +371,17 @@ public class RoleBasedScopesIssuer extends AbstractScopesIssuer implements Scope
         List<String> authorizedScopes;
         List<String> scopes = new ArrayList<>();
         List<String> requestedScopes = new ArrayList<>(Arrays.asList(tokReqMsgCtx.getScope()));
-        for (String scope : requestedScopes) {
-            // If requestedScopes contains Product REST APIs (Publisher/DevPortal/Admin) scopes, just let them pass to
-            // the final scope list returned from RoleBasedScopeIssuer. This is because RoleBasedScopeIssuer is not
-            // responsible for validating Product REST API scopes. Those will be handled by the SystemScopeIssuer.
-            if (checkForProductRestAPIScopes(scope)) {
-                scopes.add(scope);
+        boolean isRestrictApimRestApiScopes = ServiceReferenceHolder.isRestrictApimRestApiScopes();
+        boolean isRestrictUnassignedScopes = ServiceReferenceHolder.isRestrictUnassignedScopes();
+        if (!(isRestrictUnassignedScopes && isRestrictApimRestApiScopes)) {
+            for (String scope : requestedScopes) {
+                // If requestedScopes contains Product REST APIs (Publisher/DevPortal/Admin) scopes, just let
+                // them pass to the final scope list returned from RoleBasedScopeIssuer. This is because
+                // RoleBasedScopeIssuer is not responsible for validating Product REST API scopes. Those will be
+                // handled by SystemScopeIssuer.
+                if (checkForProductRestAPIScopes(scope)) {
+                    scopes.add(scope);
+                }
             }
         }
         requestedScopes.removeAll(scopes);


### PR DESCRIPTION
## Purpose
This PR will add a system property to avoid whitelisting product rest apis scopes in km connector in iskm setup.
If someone needs to restrict whitelisting product rest apis scopes, he needs to define the follwing 2 system propertise as true.
Sytem properties: 
`restrict.apim.restapi.scopes=true`
`restrict.unassigned.scopes=true`

Startup:

`./wso2server.sh -Drestrict.unassigned.scopes=true -Drestrict.unassigned.scopes=true
`
## Fixes
- https://github.com/wso2/api-manager/issues/2363
