### PR TITLE
Fix issues reported by maven-javadoc-plugin in Jenkins build

### DIFF
--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -552,7 +552,8 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
      *
      * @param appInfoRequest oAuth application properties will contain in this object
      * @return OAuthApplicationInfo with created oAuth application details.
-     * @throws org.wso2.carbon.apimgt.api.APIManagementException
+     * @throws org.wso2.carbon.apimgt.api.APIManagementException    Failure to obtain application information,
+     *                                                              or mismatching consumer key and secret.
      */
     @Override
     public OAuthApplicationInfo mapOAuthApplication(OAuthAppRequest appInfoRequest)

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/utils/AttributeMapper.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/utils/AttributeMapper.java
@@ -79,10 +79,11 @@ public class AttributeMapper {
     }
 
     /**
-     * Return claims as a map of <ClaimUri (which is mapped to SCIM attribute uri),ClaimValue>.
+     * Return claims as a map of ClaimUri (which is mapped to SCIM attribute uri),ClaimValue.
      *
      * @param scimObject SCIM object.
      * @return A map of claims.
+     * @throws APIManagementException If an error occurs while getting claims.
      */
     public static Map<String, String> getClaimsMap(AbstractSCIMObject scimObject) throws APIManagementException {
         Map<String, String> claimsMap = new HashMap<>();


### PR DESCRIPTION
## Purpose
> $Subject at [1]

[1] https://wso2.org/jenkins/job/apim-extensions/job/apim-km-wso2is_2.x/6/consoleFull
```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (attach-javadocs) on project wso2is7.key.manager: MavenReportException: Error while generating Javadoc: 
[INFO] [ERROR] Exit code: 1 - /home/jenkins/workspace/apim-extensions/apim-km-wso2is_2.x/target/checkout/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java:555: warning: no description for @throws
[INFO] [ERROR]      * @throws org.wso2.carbon.apimgt.api.APIManagementException
[INFO] [ERROR]        ^
[INFO] [ERROR] /home/jenkins/workspace/apim-extensions/apim-km-wso2is_2.x/target/checkout/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/utils/AttributeMapper.java:82: error: malformed HTML
[INFO] [ERROR]      * Return claims as a map of <ClaimUri (which is mapped to SCIM attribute uri),ClaimValue>.
[INFO] [ERROR]                                  ^
[INFO] [ERROR] /home/jenkins/workspace/apim-extensions/apim-km-wso2is_2.x/target/checkout/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/utils/AttributeMapper.java:82: error: bad use of '>'
[INFO] [ERROR]      * Return claims as a map of <ClaimUri (which is mapped to SCIM attribute uri),ClaimValue>.
[INFO] [ERROR]                                                                                              ^
[INFO] [ERROR] /home/jenkins/workspace/apim-extensions/apim-km-wso2is_2.x/target/checkout/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/utils/AttributeMapper.java:87: warning: no @throws for org.wso2.carbon.apimgt.api.APIManagementException
[INFO] [ERROR]     public static Map<String, String> getClaimsMap(AbstractSCIMObject scimObject) throws APIManagementException {
[INFO] [ERROR]                                       ^
[INFO] [ERROR] 
[INFO] [ERROR] Command line was: /build/software/java/jdk1.8.0_171/jre/../bin/javadoc @options @packages
[INFO] [ERROR] 
[INFO] [ERROR] Refer to the generated Javadoc files in '/home/jenkins/workspace/apim-extensions/apim-km-wso2is_2.x/target/checkout/components/wso2is7.key.manager/target/apidocs' dir.
[INFO] [ERROR] -> [Help 1]
```