### PR TITLE
Add typ header validation for access tokens

### DIFF
--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
@@ -22,6 +22,7 @@ import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.KeyManagerConnectorConfiguration;
 import org.wso2.carbon.apimgt.impl.DefaultKeyManagerConnectorConfiguration;
+import org.wso2.carbon.apimgt.impl.jwt.TypeEnforcedJWTValidatorImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,7 +47,7 @@ public class WSO2ISConnectorConfiguration extends DefaultKeyManagerConnectorConf
     @Override
     public String getJWTValidator() {
 
-        return null;
+        return TypeEnforcedJWTValidatorImpl.class.getName();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
     </scm>
     <properties>
         <common.codec.version>1.15</common.codec.version>
-        <carbon.apimgt.version>9.27.0</carbon.apimgt.version>
+        <carbon.apimgt.version>9.29.120.34</carbon.apimgt.version>
         <carbon.identity.version>5.25.686</carbon.identity.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
         <json.simple.version>1.1</json.simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
     </scm>
     <properties>
         <common.codec.version>1.15</common.codec.version>
-        <carbon.apimgt.version>9.29.120.34</carbon.apimgt.version>
+        <carbon.apimgt.version>9.29.191</carbon.apimgt.version>
         <carbon.identity.version>5.25.686</carbon.identity.version>
         <carbon.identity-oauth2-grant-jwt.version>2.2.4</carbon.identity-oauth2-grant-jwt.version>
         <json.simple.version>1.1</json.simple.version>


### PR DESCRIPTION
## Purpose
This PR enables `typ` header validation for access tokens.

The `typ` header validation can be enforced via the following configuration
#### deployment.toml:
```toml
[apim.token.validation]
enforce_type_header_validation = true
```
Default: `false`

Related to https://github.com/wso2/api-manager/issues/2948
 
## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/12485