### PR TITLE
Add Support for RBAC in WSO2 IS7 Key Manager

### DIFF
--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7ConnectorConfiguration.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7ConnectorConfiguration.java
@@ -58,8 +58,6 @@ public class WSO2IS7ConnectorConfiguration implements KeyManagerConnectorConfigu
         configurationDtoList
                 .add(new ConfigurationDto("Password", "Password", "input",
                         "Password of Admin user", "", true, true, Collections.emptyList(), false));
-
-        // TODO finalize the following new ones
         configurationDtoList.add(new ConfigurationDto("api_resource_management_endpoint",
                 "WSO2 Identity Server 7 API Resource Management Endpoint", "input",
                 String.format("E.g., %s/api/server/v1/api-resources",

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7ConnectorConfiguration.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7ConnectorConfiguration.java
@@ -58,6 +58,19 @@ public class WSO2IS7ConnectorConfiguration implements KeyManagerConnectorConfigu
         configurationDtoList
                 .add(new ConfigurationDto("Password", "Password", "input",
                         "Password of Admin user", "", true, true, Collections.emptyList(), false));
+
+        // TODO finalize the following new ones
+        configurationDtoList.add(new ConfigurationDto("api_resource_management_endpoint",
+                "WSO2 Identity Server 7 API Resource Management Endpoint", "input",
+                String.format("E.g., %s/api/server/v1/api-resources",
+                        org.wso2.carbon.apimgt.api.APIConstants.DEFAULT_KEY_MANAGER_HOST), "", true, false,
+                Collections.emptyList(), false));
+        configurationDtoList.add(new ConfigurationDto("is7_roles_endpoint",
+                "WSO2 Identity Server 7 Roles Endpoint", "input",
+                String.format("E.g., %s/scim2/v2/Roles",
+                        org.wso2.carbon.apimgt.api.APIConstants.DEFAULT_KEY_MANAGER_HOST), "", true, false,
+                Collections.emptyList(), false));
+
         return configurationDtoList;
     }
 

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -862,8 +862,6 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
      */
     @Override
     public Scope getScopeByName(String name) throws APIManagementException {
-        // TODO Check - Why do we really need the validateScopes method? That's the only usage for this method
-        // TODO Test that usage
 
         String wso2IS7APIResourceId = getWSO2IS7APIResourceId();
         if (wso2IS7APIResourceId != null) {
@@ -1150,9 +1148,8 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
      * @param scopes Scope set to validate
      * @throws APIManagementException if an error occurs while validating and populating
      */
-    @Override // TODO [TEST]?
+    @Override
     public void validateScopes(Set<Scope> scopes) throws APIManagementException {
-        // TODO Why do we need this method? It's just setting on top of legacy scopes, but nothing to do with IS7 scopes
 
         for (Scope scope : scopes) {
             Scope sharedScope = getScopeByName(scope.getKey());

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceInfo.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceInfo.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Represents the client information returned from WSO2 Identity Server 7.
+ */
+public class WSO2IS7APIResourceInfo {
+
+    public WSO2IS7APIResourceInfo() {}
+
+    @SerializedName("id")
+    private String id;
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("description")
+    private String description;
+    @SerializedName("identifier")
+    private String identifier;
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("requiresAuthorization")
+    private boolean requiresAuthorization;
+
+    @SerializedName("scopes")
+    private List<WSO2IS7APIResourceScopeInfo> scopes;
+
+
+    // TODO Properties? do we need, and can we survive without this
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public boolean isRequiresAuthorization() {
+        return requiresAuthorization;
+    }
+
+    public void setRequiresAuthorization(boolean requiresAuthorization) {
+        this.requiresAuthorization = requiresAuthorization;
+    }
+
+    public List<WSO2IS7APIResourceScopeInfo> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<WSO2IS7APIResourceScopeInfo> scopes) {
+        this.scopes = scopes;
+    }
+}

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceInfo.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceInfo.java
@@ -50,9 +50,6 @@ public class WSO2IS7APIResourceInfo {
     private List<WSO2IS7APIResourceScopeInfo> scopes;
 
 
-    // TODO Properties? do we need, and can we survive without this
-
-
     public String getId() {
         return id;
     }
@@ -107,5 +104,19 @@ public class WSO2IS7APIResourceInfo {
 
     public void setScopes(List<WSO2IS7APIResourceScopeInfo> scopes) {
         this.scopes = scopes;
+    }
+
+    public static class AddedScopesInfo {
+
+        @SerializedName("addedScopes")
+        private List<WSO2IS7APIResourceScopeInfo> addedScopes;
+
+        public List<WSO2IS7APIResourceScopeInfo> getAddedScopes() {
+            return addedScopes;
+        }
+
+        public void setAddedScopes(List<WSO2IS7APIResourceScopeInfo> addedScopes) {
+            this.addedScopes = addedScopes;
+        }
     }
 }

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceManagementClient.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceManagementClient.java
@@ -29,7 +29,7 @@ import org.wso2.carbon.apimgt.impl.kmclient.KeyManagerClientException;
 import java.util.Map;
 
 /**
- * Represents the WSO2 Identity Server 7 DCR client.
+ * Represents the WSO2 Identity Server 7 API Resource Management client.
  */
 public interface WSO2IS7APIResourceManagementClient {
 
@@ -49,6 +49,11 @@ public interface WSO2IS7APIResourceManagementClient {
     @Headers("Content-Type: application/json")
     void patchAPIResource(@Param("apiResourceId") String apiResourceId, JsonObject payload)
             throws KeyManagerClientException;
+
+    @RequestLine("PATCH /{apiResourceId}/scopes/{scopeName}")
+    @Headers("Content-Type: application/json")
+    void patchAPIResourceScope(@Param("apiResourceId") String apiResourceId, @Param("scopeName") String scopeName,
+                               JsonObject payload) throws KeyManagerClientException;
 
     @RequestLine("DELETE /{apiResourceId}/scopes/{scopeName}")
     @Headers("Content-Type: application/json")

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceManagementClient.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceManagementClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import feign.Headers;
+import feign.Param;
+import feign.QueryMap;
+import feign.RequestLine;
+import org.wso2.carbon.apimgt.impl.kmclient.KeyManagerClientException;
+
+import java.util.Map;
+
+/**
+ * Represents the WSO2 Identity Server 7 DCR client.
+ */
+public interface WSO2IS7APIResourceManagementClient {
+
+    @RequestLine("POST ")
+    @Headers("Content-Type: application/json")
+    WSO2IS7APIResourceInfo createAPIResource(WSO2IS7APIResourceInfo apiResourceInfo) throws KeyManagerClientException;
+
+    @RequestLine("GET ?{parameters}")
+    @Headers("Content-Type: application/json")
+    JsonObject getAPIResources(@QueryMap Map<String, String> parameters) throws KeyManagerClientException;
+
+    @RequestLine("GET /{apiResourceId}/scopes")
+    @Headers("Content-Type: application/json")
+    JsonArray getAPIResourceScopes(@Param("apiResourceId") String apiResourceId) throws KeyManagerClientException;
+
+    @RequestLine("PATCH /{apiResourceId}")
+    @Headers("Content-Type: application/json")
+    void patchAPIResource(@Param("apiResourceId") String apiResourceId, JsonObject payload)
+            throws KeyManagerClientException;
+
+    @RequestLine("DELETE /{apiResourceId}/scopes/{scopeName}")
+    @Headers("Content-Type: application/json")
+    void deleteScopeFromAPIResource(@Param("apiResourceId") String apiResourceId, @Param("scopeName") String scopeName)
+            throws KeyManagerClientException;
+
+}

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceManagementClient.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceManagementClient.java
@@ -47,13 +47,13 @@ public interface WSO2IS7APIResourceManagementClient {
 
     @RequestLine("PATCH /{apiResourceId}")
     @Headers("Content-Type: application/json")
-    void patchAPIResource(@Param("apiResourceId") String apiResourceId, JsonObject payload)
-            throws KeyManagerClientException;
+    void patchAPIResource(@Param("apiResourceId") String apiResourceId,
+                          WSO2IS7APIResourceInfo.AddedScopesInfo addedScopes) throws KeyManagerClientException;
 
     @RequestLine("PATCH /{apiResourceId}/scopes/{scopeName}")
     @Headers("Content-Type: application/json")
     void patchAPIResourceScope(@Param("apiResourceId") String apiResourceId, @Param("scopeName") String scopeName,
-                               JsonObject payload) throws KeyManagerClientException;
+                               WSO2IS7APIResourceScopeInfo scope) throws KeyManagerClientException;
 
     @RequestLine("DELETE /{apiResourceId}/scopes/{scopeName}")
     @Headers("Content-Type: application/json")

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceScopeInfo.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7APIResourceScopeInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents the client information returned from WSO2 Identity Server 7.
+ */
+public class WSO2IS7APIResourceScopeInfo {
+
+    public WSO2IS7APIResourceScopeInfo() {}
+
+    public WSO2IS7APIResourceScopeInfo(String name, String displayName, String description) {
+        this.name = name;
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("displayName")
+    private String displayName;
+
+    @SerializedName("description")
+    private String description;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7ClientInfo.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7ClientInfo.java
@@ -152,6 +152,9 @@ public class WSO2IS7ClientInfo {
     @SerializedName("request_object_encryption_enc")
     private String requestObjectEncryptionEnc;
 
+    @SerializedName("ext_allowed_audience")
+    private String extAllowedAudience;
+
     public List<String> getRedirectUris() {
         return redirectUris;
     }
@@ -480,4 +483,11 @@ public class WSO2IS7ClientInfo {
         this.requestObjectEncryptionEnc = requestObjectEncryptionEnc;
     }
 
+    public String getExtAllowedAudience() {
+        return extAllowedAudience;
+    }
+
+    public void setExtAllowedAudience(String extAllowedAudience) {
+        this.extAllowedAudience = extAllowedAudience;
+    }
 }

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7PatchRoleOperationInfo.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7PatchRoleOperationInfo.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Represents the patch role operation payload for WSO2 Identity Server 7.
+ */
+public class WSO2IS7PatchRoleOperationInfo {
+
+    @SerializedName("Operations")
+    private List<Operation> operations;
+
+    public List<Operation> getOperations() {
+        return operations;
+    }
+
+    public void setOperations(List<Operation> operations) {
+        this.operations = operations;
+    }
+
+    public static class Operation {
+
+        @SerializedName("op")
+        private String op;
+
+        @SerializedName("path")
+        private String path;
+
+        @SerializedName("value")
+        private Value value;
+
+        public String getOp() {
+            return op;
+        }
+
+        public void setOp(String op) {
+            this.op = op;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public Value getValue() {
+            return value;
+        }
+
+        public void setValue(Value value) {
+            this.value = value;
+        }
+    }
+
+    public static class Value {
+
+        @SerializedName("permissions")
+        private List<Permission> permissions;
+
+        public List<Permission> getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(List<Permission> permissions) {
+            this.permissions = permissions;
+        }
+    }
+
+    public static class Permission {
+
+        @SerializedName("value")
+        private String value;
+
+        @SerializedName("display")
+        private String display;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getDisplay() {
+            return display;
+        }
+
+        public void setDisplay(String display) {
+            this.display = display;
+        }
+    }
+}

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7RoleInfo.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7RoleInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the client information returned from WSO2 Identity Server 7.
+ */
+public class WSO2IS7RoleInfo {
+
+    public WSO2IS7RoleInfo() {}
+
+    @SerializedName("id")
+    private String id;
+
+    @SerializedName("displayName")
+    private String displayName;
+
+    @SerializedName("schemas")
+    private List<String> schemas;
+
+    @SerializedName("permissions")
+    private List<Map<String, String>> permissions;
+
+    @SerializedName("audience")
+    private Map<String, String> audience;
+
+    @SerializedName("meta")
+    private Map<String, String> meta;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public List<String> getSchemas() {
+        return schemas;
+    }
+
+    public void setSchemas(List<String> schemas) {
+        this.schemas = schemas;
+    }
+
+    public List<Map<String, String>> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(List<Map<String, String>> permissions) {
+        this.permissions = permissions;
+    }
+
+    public Map<String, String> getAudience() {
+        return audience;
+    }
+
+    public void setAudience(Map<String, String> audience) {
+        this.audience = audience;
+    }
+
+    public Map<String, String> getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Map<String, String> meta) {
+        this.meta = meta;
+    }
+}

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7SCIMRolesClient.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7SCIMRolesClient.java
@@ -43,6 +43,7 @@ public interface WSO2IS7SCIMRolesClient {
 
     @RequestLine("PATCH /{roleId}")
     @Headers("Content-Type: application/json")
-    void patchRole(@Param("roleId") String roleId, JsonObject payload) throws KeyManagerClientException;
+    void patchRole(@Param("roleId") String roleId, WSO2IS7PatchRoleOperationInfo patchRoleOperationInfo)
+            throws KeyManagerClientException;
 
 }

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7SCIMRolesClient.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7SCIMRolesClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client.model;
+
+import com.google.gson.JsonObject;
+import feign.Headers;
+import feign.Param;
+import feign.QueryMap;
+import feign.RequestLine;
+import org.wso2.carbon.apimgt.impl.kmclient.KeyManagerClientException;
+
+import java.util.Map;
+
+/**
+ * Represents the WSO2 Identity Server 7 DCR client.
+ */
+public interface WSO2IS7SCIMRolesClient {
+
+    @RequestLine("GET /{roleId}")
+    @Headers("Content-Type: application/json")
+    WSO2IS7RoleInfo getRole(@Param("roleId") String roleId) throws KeyManagerClientException;
+
+    @RequestLine("POST ")
+    @Headers("Content-Type: application/json")
+    WSO2IS7RoleInfo createRole(WSO2IS7RoleInfo role) throws KeyManagerClientException;
+
+    @RequestLine("GET ?{parameters}")
+    @Headers("Content-Type: application/json")
+    JsonObject filterRoles(@QueryMap Map<String, String> parameters) throws KeyManagerClientException;
+
+    @RequestLine("PATCH /{roleId}")
+    @Headers("Content-Type: application/json")
+    void patchRole(@Param("roleId") String roleId, JsonObject payload) throws KeyManagerClientException;
+
+}

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7SCIMRolesClient.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/model/WSO2IS7SCIMRolesClient.java
@@ -21,14 +21,11 @@ package org.wso2.is7.client.model;
 import com.google.gson.JsonObject;
 import feign.Headers;
 import feign.Param;
-import feign.QueryMap;
 import feign.RequestLine;
 import org.wso2.carbon.apimgt.impl.kmclient.KeyManagerClientException;
 
-import java.util.Map;
-
 /**
- * Represents the WSO2 Identity Server 7 DCR client.
+ * Represents the WSO2 Identity Server SCIM2 Roles client.
  */
 public interface WSO2IS7SCIMRolesClient {
 
@@ -40,9 +37,9 @@ public interface WSO2IS7SCIMRolesClient {
     @Headers("Content-Type: application/json")
     WSO2IS7RoleInfo createRole(WSO2IS7RoleInfo role) throws KeyManagerClientException;
 
-    @RequestLine("GET ?{parameters}")
+    @RequestLine("POST /.search")
     @Headers("Content-Type: application/json")
-    JsonObject filterRoles(@QueryMap Map<String, String> parameters) throws KeyManagerClientException;
+    JsonObject searchRoles(JsonObject payload) throws KeyManagerClientException;
 
     @RequestLine("PATCH /{roleId}")
     @Headers("Content-Type: application/json")


### PR DESCRIPTION
## Purpose
> $Subject, with WSO2 IS7 native scopes & roles. Fixes https://github.com/wso2/api-manager/issues/2937

## Goals
> $Subject.

## Approach
- We will be using the IS7 API Resource called `User-defined-oauth2-resource` to contain scopes(permissions). This is in par with the IS7 migration guide [1].
- For each scope that we create in APIM (both local & shared), a IS7 scope(permission) will be created in the `User-defined-oauth2-resource` IS7 API Resource.
- Prior to IS7, based on our legacy scope model, we had scope-to-role bindings as `scope -> [roles]`. In IS7, it is in the form of `role -> [permissions]`. Therefore scope-to-role bindings which goes as `MyScope -> [MyRole1, MyRole2]` in APIM, will have the following in IS7:
  - A scope called `MyScope`.
  - Two roles, namely `MyRole1` and `MyRole2`. Each of these will have the `MyScope` scope(permission).
- Before IS7, we used to talk to a **Scope endpoint** (`https://localhost:9444/api/identity/oauth2/v1.0/scopes`) to handle scope-related operations. In IS7, we will use the following:
  - **IS7 API Resource Management endpoint** (`https://localhost:9444/api/server/v1/api-resources`) - to handle IS7 Scopes(permissions)
  - **IS7 Roles endpoint** (`https://localhost:9444/scim2/v2/Roles`) - to handle IS7 Roles.

[1] https://github.com/wso2-enterprise/migration-docs/blob/main/identity-server/migration-docs/is-7.0.0/migrating-authorization-model.md