### PR TITLE
Make IS7 role creation configurable

### DIFF
--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7ConnectorConfiguration.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7ConnectorConfiguration.java
@@ -68,7 +68,10 @@ public class WSO2IS7ConnectorConfiguration implements KeyManagerConnectorConfigu
                 String.format("E.g., %s/scim2/v2/Roles",
                         org.wso2.carbon.apimgt.api.APIConstants.DEFAULT_KEY_MANAGER_HOST), "", true, false,
                 Collections.emptyList(), false));
-
+        configurationDtoList.add(new ConfigurationDto("enable_roles_creation",
+                "Create roles in WSO2 Identity Server 7", "checkbox",
+                "Create roles in WSO2 Identity Server 7, corresponding to the roles used in WSO2 API Manager.",
+                "Enable", false, false, Collections.singletonList("Enable"), false));
         return configurationDtoList;
     }
 

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -1587,8 +1587,7 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
         if (roleName.startsWith("Internal/")) {
             return roleName.replace("Internal/", "");
         } else if (roleName.startsWith("Application/")) {
-            throw new APIManagementException("Role: " + roleName +
-                    " is invalid since Application roles are not supported in WSO2 IS7.");
+            throw new APIManagementException("Role: " + roleName + " is invalid.");
         }
         return "system_primary_" + roleName;
     }


### PR DESCRIPTION
## Purpose
> $Subject. Fixes https://github.com/wso2/api-manager/issues/3310 .

With this change, the **Create roles in WSO2 Identity Server 7** option has been introduced.

Switching this on will create roles in WSO2 IS7 (this defaults to false). Otherwise, the user has to create a role in WSO2 IS7 themselves.

If role creation is on, the following naming conventions are followed when creating/accessing roles in WSO2 IS7, corresponding to the types of WSO2 APIM roles. This is in par with the approach of the WSO2 IS Migration client.

- _PRIMARY_ roles in APIM (eg: `manager`):
    - Create the role `system_primary_manager` in IS7.
    - We won't create any user groups or assign roles to them unlike in IS migration client.
- _Internal_ roles in APIM (eg: `Internal/publisher`):
    - Create the role publisher in IS7.
- _Application_ roles: We won't be using these going forward

<img width="1007" alt="Screenshot 2024-12-10 at 00 37 06" src="https://github.com/user-attachments/assets/c2bef4ba-fb3a-4261-9be9-e9a3b569b440">


