### PR TITLE
Application scopes for client credentials grant type

### DIFF
--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponent.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponent.java
@@ -53,6 +53,7 @@ public class KeyManagerCoreServiceComponent {
     private static final Log log = LogFactory.getLog(KeyManagerCoreServiceComponent.class);
     private static final String RESTRICT_UNASSIGNED_SCOPES = "restrict.unassigned.scopes";
     private static final String RESTRICT_APIM_REST_API_SCOPES = "restrict.apim.restapi.scopes";
+    private static final String MERGE_APPLICATION_SCOPES = "merge.application.scopes";
 
     @Activate
     protected void activate(ComponentContext cxt) {
@@ -74,6 +75,16 @@ public class KeyManagerCoreServiceComponent {
             boolean restrictApimRestApiScopes = Boolean.parseBoolean(System.getProperty(
                     RESTRICT_APIM_REST_API_SCOPES));
             ServiceReferenceHolder.setRestrictApimRestApiScopes(restrictApimRestApiScopes);
+
+            // When this property is enabled, application scopes will be merged with final authorized scopes in client
+            // credential grant type. Otherwise, only application scopes will be returned. By default, this is set to
+            // true.
+            if (System.getProperty(MERGE_APPLICATION_SCOPES) == null) {
+                ServiceReferenceHolder.setMergeApplicationScopes(true);
+            } else {
+                boolean mergeApplicationScopes = Boolean.parseBoolean(System.getProperty(MERGE_APPLICATION_SCOPES));
+                ServiceReferenceHolder.setMergeApplicationScopes(mergeApplicationScopes);
+            }
 
         } catch (Throwable e) {
             log.error(e.getMessage(), e);

--- a/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolder.java
+++ b/components/wso2is.key.manager.core/src/main/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolder.java
@@ -36,6 +36,7 @@ public class ServiceReferenceHolder {
     private static ConfigurationContextService contextService;
     private static boolean restrictUnassignedScopes;
     private static boolean restrictApimRestApiScopes;
+    private static boolean mergeApplicationScopes;
 
     private ServiceReferenceHolder() {
 
@@ -94,5 +95,13 @@ public class ServiceReferenceHolder {
 
     public static void setRestrictApimRestApiScopes(boolean restrictProductRestApiScopes) {
         ServiceReferenceHolder.restrictApimRestApiScopes = restrictProductRestApiScopes;
+    }
+
+    public static boolean isMergeApplicationScopes() {
+        return mergeApplicationScopes;
+    }
+
+    public static void setMergeApplicationScopes(boolean mergeApplicationScopes) {
+        ServiceReferenceHolder.mergeApplicationScopes = mergeApplicationScopes;
     }
 }

--- a/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/ApplicationDTO.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/ApplicationDTO.java
@@ -31,6 +31,7 @@ public class ApplicationDTO   {
     private Boolean pkceSupportPlain = null;
     private Boolean bypassClientCredentials = null;
     private String tokenTypeExtension = null;
+    private List<String> applicationScopes = new ArrayList<>();
 
   /**
    **/
@@ -287,6 +288,23 @@ public class ApplicationDTO   {
     this.tokenTypeExtension = tokenTypeExtension;
   }
 
+  /**
+   **/
+  public ApplicationDTO applicationScopes(List<String> applicationScopes) {
+    this.applicationScopes = applicationScopes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("application_scopes")
+  public List<String> getApplicationScopes() {
+    return applicationScopes;
+  }
+  public void setApplicationScopes(List<String> applicationScopes) {
+    this.applicationScopes = applicationScopes;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -311,12 +329,13 @@ public class ApplicationDTO   {
         Objects.equals(pkceMandatory, application.pkceMandatory) &&
         Objects.equals(pkceSupportPlain, application.pkceSupportPlain) &&
         Objects.equals(bypassClientCredentials, application.bypassClientCredentials) &&
-        Objects.equals(tokenTypeExtension, application.tokenTypeExtension);
+        Objects.equals(tokenTypeExtension, application.tokenTypeExtension) &&
+        Objects.equals(applicationScopes, application.applicationScopes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(clientId, clientSecret, clientSecretExpiresAt, redirectUris, clientName, grantTypes, extApplicationOwner, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, pkceMandatory, pkceSupportPlain, bypassClientCredentials, tokenTypeExtension);
+    return Objects.hash(clientId, clientSecret, clientSecretExpiresAt, redirectUris, clientName, grantTypes, extApplicationOwner, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, pkceMandatory, pkceSupportPlain, bypassClientCredentials, tokenTypeExtension, applicationScopes);
   }
 
   @Override
@@ -339,6 +358,7 @@ public class ApplicationDTO   {
     sb.append("    pkceSupportPlain: ").append(toIndentedString(pkceSupportPlain)).append("\n");
     sb.append("    bypassClientCredentials: ").append(toIndentedString(bypassClientCredentials)).append("\n");
     sb.append("    tokenTypeExtension: ").append(toIndentedString(tokenTypeExtension)).append("\n");
+    sb.append("    applicationScopes: ").append(toIndentedString(applicationScopes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/RegistrationRequestDTO.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/RegistrationRequestDTO.java
@@ -43,6 +43,7 @@ public class RegistrationRequestDTO   {
     private Boolean pkceMandatory = null;
     private Boolean pkceSupportPlain = null;
     private Boolean bypassClientCredentials = null;
+    private List<String> applicationScopes = new ArrayList<>();
 
   /**
    **/
@@ -505,6 +506,23 @@ public class RegistrationRequestDTO   {
     this.bypassClientCredentials = bypassClientCredentials;
   }
 
+  /**
+   **/
+  public RegistrationRequestDTO applicationScopes(List<String> applicationScopes) {
+    this.applicationScopes = applicationScopes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("application_scopes")
+  public List<String> getApplicationScopes() {
+    return applicationScopes;
+  }
+  public void setApplicationScopes(List<String> applicationScopes) {
+    this.applicationScopes = applicationScopes;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -541,12 +559,13 @@ public class RegistrationRequestDTO   {
         Objects.equals(backchannelLogoutSessionRequired, registrationRequest.backchannelLogoutSessionRequired) &&
         Objects.equals(pkceMandatory, registrationRequest.pkceMandatory) &&
         Objects.equals(pkceSupportPlain, registrationRequest.pkceSupportPlain) &&
-        Objects.equals(bypassClientCredentials, registrationRequest.bypassClientCredentials);
+        Objects.equals(bypassClientCredentials, registrationRequest.bypassClientCredentials) &&
+        Objects.equals(applicationScopes, registrationRequest.applicationScopes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationDisplayName, applicationType, tokenTypeExtension, extApplicationOwner, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, jwksUri, url, extParamClientId, extParamClientSecret, contacts, postLogoutRedirectUris, requestUris, responseTypes, extParamSpTemplate, backchannelLogoutUri, backchannelLogoutSessionRequired, pkceMandatory, pkceSupportPlain, bypassClientCredentials);
+    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationDisplayName, applicationType, tokenTypeExtension, extApplicationOwner, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, jwksUri, url, extParamClientId, extParamClientSecret, contacts, postLogoutRedirectUris, requestUris, responseTypes, extParamSpTemplate, backchannelLogoutUri, backchannelLogoutSessionRequired, pkceMandatory, pkceSupportPlain, bypassClientCredentials, applicationScopes);
   }
 
   @Override
@@ -581,6 +600,7 @@ public class RegistrationRequestDTO   {
     sb.append("    pkceMandatory: ").append(toIndentedString(pkceMandatory)).append("\n");
     sb.append("    pkceSupportPlain: ").append(toIndentedString(pkceSupportPlain)).append("\n");
     sb.append("    bypassClientCredentials: ").append(toIndentedString(bypassClientCredentials)).append("\n");
+    sb.append("    applicationScopes: ").append(toIndentedString(applicationScopes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/UpdateRequestDTO.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/gen/java/org/wso2/is/key/manager/operations/endpoint/dto/UpdateRequestDTO.java
@@ -33,6 +33,7 @@ public class UpdateRequestDTO   {
     private Boolean pkceMandatory = null;
     private Boolean pkceSupportPlain = null;
     private Boolean bypassClientCredentials = null;
+    private List<String> applicationScopes = new ArrayList<>();
 
   /**
    **/
@@ -323,6 +324,23 @@ public class UpdateRequestDTO   {
     this.bypassClientCredentials = bypassClientCredentials;
   }
 
+  /**
+   **/
+  public UpdateRequestDTO applicationScopes(List<String> applicationScopes) {
+    this.applicationScopes = applicationScopes;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("application_scopes")
+  public List<String> getApplicationScopes() {
+    return applicationScopes;
+  }
+  public void setApplicationScopes(List<String> applicationScopes) {
+    this.applicationScopes = applicationScopes;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -349,12 +367,13 @@ public class UpdateRequestDTO   {
         Objects.equals(extIdTokenLifetime, updateRequest.extIdTokenLifetime) &&
         Objects.equals(pkceMandatory, updateRequest.pkceMandatory) &&
         Objects.equals(pkceSupportPlain, updateRequest.pkceSupportPlain) &&
-        Objects.equals(bypassClientCredentials, updateRequest.bypassClientCredentials);
+        Objects.equals(bypassClientCredentials, updateRequest.bypassClientCredentials) &&
+        Objects.equals(applicationScopes, updateRequest.applicationScopes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationDisplayName, tokenTypeExtension, extApplicationOwner, backchannelLogoutUri, backchannelLogoutSessionRequired, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, pkceMandatory, pkceSupportPlain, bypassClientCredentials);
+    return Objects.hash(redirectUris, clientName, clientId, clientSecret, grantTypes, applicationDisplayName, tokenTypeExtension, extApplicationOwner, backchannelLogoutUri, backchannelLogoutSessionRequired, extApplicationTokenLifetime, extUserTokenLifetime, extRefreshTokenLifetime, extIdTokenLifetime, pkceMandatory, pkceSupportPlain, bypassClientCredentials, applicationScopes);
   }
 
   @Override
@@ -379,6 +398,7 @@ public class UpdateRequestDTO   {
     sb.append("    pkceMandatory: ").append(toIndentedString(pkceMandatory)).append("\n");
     sb.append("    pkceSupportPlain: ").append(toIndentedString(pkceSupportPlain)).append("\n");
     sb.append("    bypassClientCredentials: ").append(toIndentedString(bypassClientCredentials)).append("\n");
+    sb.append("    applicationScopes: ").append(toIndentedString(applicationScopes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplication.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplication.java
@@ -41,6 +41,7 @@ public class ExtendedApplication extends Application implements Serializable {
     private Boolean pkceSupportPlain = false;
     private Boolean bypassClientCredentials = false;
     private String tokenType;
+    private List<String> applicationScopes = null;
 
     public long getApplicationAccessTokenLifeTime() {
 
@@ -131,4 +132,13 @@ public class ExtendedApplication extends Application implements Serializable {
     public void setTokenType(String tokenType) {
         this.tokenType = tokenType;
     }
+
+    public List<String> getApplicationScopes() {
+        return this.applicationScopes;
+    }
+
+    public void setApplicationScopes(List<String> applicationScopes) {
+        this.applicationScopes = applicationScopes;
+    }
+
 }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationRegistrationRequest.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationRegistrationRequest.java
@@ -21,6 +21,8 @@ package org.wso2.is.key.manager.operations.endpoint.dcr.bean;
 import org.wso2.carbon.identity.oauth.dcr.bean.ApplicationRegistrationRequest;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This object contains the context related to OAuth application registration request.
@@ -38,6 +40,8 @@ public class ExtendedApplicationRegistrationRequest extends ApplicationRegistrat
     private Boolean pkceMandatory = false;
     private Boolean pkceSupportPlain = false;
     private Boolean bypassClientCredentials = false;
+    // List of scopes that can be requested in client credentials grant type
+    private List<String> applicationScopes = new ArrayList<String>();
 
     public Long getApplicationAccessTokenLifeTime() {
 
@@ -130,4 +134,19 @@ public class ExtendedApplicationRegistrationRequest extends ApplicationRegistrat
     public void setBypassClientCredentials(Boolean bypassClientCredentials) {
         this.bypassClientCredentials = bypassClientCredentials;
     }
+
+    /**
+     *
+     * @return applicationScopes
+     */
+    public List<String> getApplicationScopes() {
+
+        return applicationScopes;
+    }
+
+    public void setApplicationScopes(List<String> applicationScopes) {
+
+        this.applicationScopes = applicationScopes;
+    }
+
 }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationUpdateRequest.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/bean/ExtendedApplicationUpdateRequest.java
@@ -20,6 +20,9 @@ package org.wso2.is.key.manager.operations.endpoint.dcr.bean;
 
 import org.wso2.carbon.identity.oauth.dcr.bean.ApplicationUpdateRequest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This class used to send update request to oauth application
  */
@@ -35,6 +38,8 @@ public class ExtendedApplicationUpdateRequest extends ApplicationUpdateRequest {
     private Boolean pkceMandatory = false;
     private Boolean pkceSupportPlain = false;
     private Boolean bypassClientCredentials = false;
+    // List of scopes that can be requested in client credentials grant type
+    private List<String> applicationScopes = new ArrayList<String>();
 
     public void setApplicationAccessTokenLifeTime(Long applicationAccessTokenLifeTime) {
 
@@ -110,4 +115,15 @@ public class ExtendedApplicationUpdateRequest extends ApplicationUpdateRequest {
     public void setBypassClientCredentials(Boolean bypassClientCredentials) {
         this.bypassClientCredentials = bypassClientCredentials;
     }
+
+    public void setApplicationScopes(List<String> applicationScopes) {
+
+        this.applicationScopes = applicationScopes;
+    }
+
+    public List<String> getApplicationScopes() {
+
+        return applicationScopes;
+    }
+
 }

--- a/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/java/org/wso2/is/key/manager/operations/endpoint/dcr/util/ExtendedDCRMUtils.java
@@ -73,6 +73,7 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         appRegistrationRequest.setPkceMandatory(registrationRequestDTO.isPkceMandatory());
         appRegistrationRequest.setPkceSupportPlain(registrationRequestDTO.isPkceSupportPlain());
         appRegistrationRequest.setBypassClientCredentials(registrationRequestDTO.isBypassClientCredentials());
+        appRegistrationRequest.setApplicationScopes(registrationRequestDTO.getApplicationScopes());
         return appRegistrationRequest;
 
     }
@@ -94,6 +95,7 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         applicationUpdateRequest.setPkceMandatory(updateRequestDTO.isPkceMandatory());
         applicationUpdateRequest.setPkceSupportPlain(updateRequestDTO.isPkceSupportPlain());
         applicationUpdateRequest.setBypassClientCredentials(updateRequestDTO.isBypassClientCredentials());
+        applicationUpdateRequest.setApplicationScopes(updateRequestDTO.getApplicationScopes());
         return applicationUpdateRequest;
 
     }
@@ -199,6 +201,7 @@ public class ExtendedDCRMUtils extends  DCRMUtils {
         applicationDTO.setPkceSupportPlain(application.getPkceSupportPlain());
         applicationDTO.setBypassClientCredentials(application.getBypassClientCredentials());
         applicationDTO.setTokenTypeExtension(application.getTokenType());
+        applicationDTO.setApplicationScopes(application.getApplicationScopes());
         return applicationDTO;
     }
 

--- a/components/wso2is.key.manager.operations.endpoint/src/main/resources/keymanager-operations.yaml
+++ b/components/wso2is.key.manager.operations.endpoint/src/main/resources/keymanager-operations.yaml
@@ -553,6 +553,10 @@ definitions:
         type: boolean
       bypassClientCredentials:
         type: boolean
+      application_scopes:
+        type: array
+        items:
+          type: string
 
     #-----------------------------------------------------
     # The Application Update Request Object
@@ -602,6 +606,10 @@ definitions:
           type: boolean
         bypassClientCredentials:
           type: boolean
+        application_scopes:
+          type: array
+          items:
+            type: string
     #-----------------------------------------------------
     # The OAuth2 Application Object
     #-----------------------------------------------------
@@ -646,3 +654,7 @@ definitions:
           type: boolean
         token_type_extension:
           type: string
+        application_scopes:
+          type: array
+          items:
+            type: string

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConnectorConfiguration.java
@@ -63,6 +63,11 @@ public class WSO2ISConnectorConfiguration extends DefaultKeyManagerConnectorConf
         configurationDtoList.add(new ConfigurationDto(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_NAME,
                 WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL, "checkbox", WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_LABEL,
                 "", false, false, Collections.singletonList(WSO2ISConstants.KM_ADMIN_AS_APP_OWNER_VALUE), false));
+        configurationDtoList
+                .add(new ConfigurationDto(WSO2ISConstants.ENABLE_APPLICATION_SCOPE_NAME,
+                        WSO2ISConstants.ENABLE_APPLICATION_SCOPE_LABEL, "checkbox",
+                        WSO2ISConstants.ENABLE_APPLICATION_SCOPE_LABEL, "", false, false,
+                        Collections.singletonList(WSO2ISConstants.ENABLE_APPLICATION_SCOPE_VALUE), false));
         configurationDtoList.addAll(super.getConnectionConfigurations());
         return configurationDtoList;
     }

--- a/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
+++ b/components/wso2is.key.manager/src/main/java/org/wso2/is/client/WSO2ISConstants.java
@@ -30,6 +30,9 @@ public class WSO2ISConstants {
     public static final String KM_ADMIN_AS_APP_OWNER_LABEL =
             "Enable admin user as the owner of created OAuth applications";
     public static final String KM_ADMIN_AS_APP_OWNER_VALUE = "Use as OAuth Application Owner";
+    public static final String ENABLE_APPLICATION_SCOPE_NAME = "enable_application_scopes";
+    public static final String ENABLE_APPLICATION_SCOPE_LABEL = "Enable application scopes for Oauth applications";
+    public static final String ENABLE_APPLICATION_SCOPE_VALUE = "Enable Application Scopes";
 
     WSO2ISConstants() {
 


### PR DESCRIPTION
This pull request introduces the ability to manage application-specific scopes in the client credentials grant type. It includes changes to support merging application scopes with authorized scopes, updates to the `ServiceReferenceHolder` and `RoleBasedScopesIssuer` classes, and modifications to several DTO classes to handle application scopes.
Related to https://github.com/wso2/api-manager/issues/3910, https://github.com/wso2/api-manager/issues/3998

### Enhancements to scope management:

* Added a new configuration property, `MERGE_APPLICATION_SCOPES`, to control whether application scopes are merged with authorized scopes in the client credentials grant type. By default, this is enabled. (`KeyManagerCoreServiceComponent.java`) [[1]](diffhunk://#diff-97ff59e2a2b6ed85bc6433ca7f2e937b1bfc360789533ae87ba6f1fe4948f785R56) [[2]](diffhunk://#diff-97ff59e2a2b6ed85bc6433ca7f2e937b1bfc360789533ae87ba6f1fe4948f785R79-R88)
* Updated `ServiceReferenceHolder` to include methods for setting and retrieving the `mergeApplicationScopes` property. (`ServiceReferenceHolder.java`) [[1]](diffhunk://#diff-74cf9c15714d13d83b7011fa8b5f9ca7e2d2750d4d67163753dc3525defbd1edR39) [[2]](diffhunk://#diff-74cf9c15714d13d83b7011fa8b5f9ca7e2d2750d4d67163753dc3525defbd1edR99-R106)

### Updates to `RoleBasedScopesIssuer`:

* Added logic to handle application scopes in the client credentials grant type, including merging application scopes with authorized scopes based on the `MERGE_APPLICATION_SCOPES` property. (`RoleBasedScopesIssuer.java`) [[1]](diffhunk://#diff-78028ed3b0ce6311eaa5eefda6fcbacc6795340b7138d3f2434160dbac284145L371-R376) [[2]](diffhunk://#diff-78028ed3b0ce6311eaa5eefda6fcbacc6795340b7138d3f2434160dbac284145R395-L402) [[3]](diffhunk://#diff-78028ed3b0ce6311eaa5eefda6fcbacc6795340b7138d3f2434160dbac284145L442-R495)
* Introduced a helper method, `getApplicationScopesFromSP`, to retrieve application scopes from service provider properties. (`RoleBasedScopesIssuer.java`)

### DTO updates for application scopes:

* Added an `applicationScopes` field to `ApplicationDTO`, `RegistrationRequestDTO`, and `UpdateRequestDTO`, along with corresponding getter, setter, and equality methods. (`ApplicationDTO.java`, `RegistrationRequestDTO.java`, `UpdateRequestDTO.java`) [[1]](diffhunk://#diff-bbbb3c57a3c857bda37036880bcc65c6410c85c0832cc43cf702bd37b1404e86R34) [[2]](diffhunk://#diff-bf20ca8b5f3b60c524c2773bfc5b1d0872457855e2c2ddefe5a9094adc48916aR46) [[3]](diffhunk://#diff-05eadc48bf2e706da49e52e1a6e94f528fb0f5a93abf1e5fad8544f0051968c0R36)
* Updated `toString`, `equals`, and `hashCode` methods in the above DTO classes to include the new `applicationScopes` field. [[1]](diffhunk://#diff-bbbb3c57a3c857bda37036880bcc65c6410c85c0832cc43cf702bd37b1404e86R361) [[2]](diffhunk://#diff-bf20ca8b5f3b60c524c2773bfc5b1d0872457855e2c2ddefe5a9094adc48916aR603) [[3]](diffhunk://#diff-05eadc48bf2e706da49e52e1a6e94f528fb0f5a93abf1e5fad8544f0051968c0L352-R376)

These changes enhance the flexibility of scope management in OAuth2 flows, particularly for client credentials, by allowing application-specific scopes to be defined and optionally merged with authorized scopes.