### PR TITLE
Fixing application-level scope authorizations configured in WSO2 IS 7.x disappear after API update

### DIFF
--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -1247,7 +1247,7 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
                 Set<String> existingScopeNames = getExistingWSO2IS7ScopeNames(wso2IS7APIResourceId);
                 nonExistingWSO2IS7Scopes = getNonExistingWSO2IS7Scopes(newScopes, existingScopeNames);
                 addScopesToWSO2IS7APIResource(wso2IS7APIResourceId, nonExistingWSO2IS7Scopes);
-                updateExistingWSO2IS7Scopes(wso2IS7APIResourceId, newScopes, existingScopeNames);
+                removeStaleRoleBindingsAndUpdateExistingScopes(wso2IS7APIResourceId, newScopes, existingScopeNames);
             } catch (KeyManagerClientException e) {
                 handleException("Failed to add scopes to WSO2 IS7 API Resource: " +
                         DEFAULT_OAUTH_2_RESOURCE_IDENTIFIER, e);
@@ -1304,8 +1304,9 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
     }
 
     /**
-     * Updates display name and description of scopes already in the IS7 API resource, and removes
-     * role-to-scope bindings that are no longer assigned in APIM. New bindings are added afterward by
+     * Removes role-to-scope bindings that are no longer assigned in APIM, and updates
+     * display name and description of already existing scopes.
+     * New bindings are added afterward by
      * {@link #createWSO2IS7RoleToScopeBindings}.
      *
      * @param wso2IS7APIResourceId   ID of the {@link #DEFAULT_OAUTH_2_RESOURCE_IDENTIFIER}
@@ -1314,7 +1315,7 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
      * @throws KeyManagerClientException Failed to patch scope metadata in IS7
      * @throws APIManagementException    Failed to remove stale role-to-scope bindings
      */
-    private void updateExistingWSO2IS7Scopes(String wso2IS7APIResourceId, Set<Scope> scopes,
+    private void removeStaleRoleBindingsAndUpdateExistingScopes(String wso2IS7APIResourceId, Set<Scope> scopes,
                                              Set<String> existingScopeNames)
             throws KeyManagerClientException, APIManagementException {
 

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -1247,8 +1247,12 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
                 Set<String> existingScopeNames = getExistingWSO2IS7ScopeNames(wso2IS7APIResourceId);
                 nonExistingWSO2IS7Scopes = getNonExistingWSO2IS7Scopes(newScopes, existingScopeNames);
                 addScopesToWSO2IS7APIResource(wso2IS7APIResourceId, nonExistingWSO2IS7Scopes);
+                updateExistingWSO2IS7Scopes(wso2IS7APIResourceId, newScopes, existingScopeNames);
             } catch (KeyManagerClientException e) {
                 handleException("Failed to add scopes to WSO2 IS7 API Resource: " +
+                        DEFAULT_OAUTH_2_RESOURCE_IDENTIFIER, e);
+            } catch (APIManagementException e) {
+                handleException("Failed to update existing scopes in WSO2 IS7 API Resource: " +
                         DEFAULT_OAUTH_2_RESOURCE_IDENTIFIER, e);
             }
         } else {
@@ -1291,12 +1295,54 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
 
         List<WSO2IS7APIResourceScopeInfo> wso2IS7ScopesToAdd = new ArrayList<>();
         for (Scope scope : newLocalScopes) {
-            if (!existingScopeNames.contains(scope.getName())) {
+            if (!existingScopeNames.contains(scope.getKey())) {
                 wso2IS7ScopesToAdd.add(new WSO2IS7APIResourceScopeInfo(scope.getKey(), scope.getName(),
                         scope.getDescription()));
             }
         }
         return wso2IS7ScopesToAdd;
+    }
+
+    /**
+     * Updates display name and description of scopes already in the IS7 API resource, and removes
+     * role-to-scope bindings that are no longer assigned in APIM. New bindings are added afterward by
+     * {@link #createWSO2IS7RoleToScopeBindings}.
+     *
+     * @param wso2IS7APIResourceId   ID of the {@link #DEFAULT_OAUTH_2_RESOURCE_IDENTIFIER}
+     * @param scopes                 Scopes from the current APIM request
+     * @param existingScopeNames     Scope keys already registered in the IS7 API resource
+     * @throws KeyManagerClientException Failed to patch scope metadata in IS7
+     * @throws APIManagementException    Failed to remove stale role-to-scope bindings
+     */
+    private void updateExistingWSO2IS7Scopes(String wso2IS7APIResourceId, Set<Scope> scopes,
+                                             Set<String> existingScopeNames)
+            throws KeyManagerClientException, APIManagementException {
+
+        boolean hasExistingScopes = scopes.stream().anyMatch(s -> existingScopeNames.contains(s.getKey()));
+        if (!hasExistingScopes) {
+            return;
+        }
+
+        JsonArray allIS7Roles = searchRoles(null);
+        for (Scope scope : scopes) {
+            if (!existingScopeNames.contains(scope.getKey())) {
+                continue;
+            }
+            // Update meta data for exiting scopes
+            WSO2IS7APIResourceScopeInfo scopeInfo = new WSO2IS7APIResourceScopeInfo();
+            scopeInfo.setDisplayName(scope.getName());
+            scopeInfo.setDescription(scope.getDescription());
+            wso2IS7APIResourceManagementClient.patchAPIResourceScope(wso2IS7APIResourceId, scope.getKey(), scopeInfo);
+
+            // Update with removed scope-to-role bindings for exiting scopes
+            List<String> existingAPIMRoles = getAPIMRolesFromIS7Roles(
+                    getWSO2IS7RolesHavingScope(scope.getKey(), allIS7Roles));
+            List<String> roleBindingsToRemove = new ArrayList<>(existingAPIMRoles);
+            roleBindingsToRemove.removeAll(getRoles(scope));
+            if (!roleBindingsToRemove.isEmpty()) {
+                removeWSO2IS7RoleToScopeBindings(scope.getKey(), roleBindingsToRemove);
+            }
+        }
     }
 
     /**
@@ -1391,6 +1437,15 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
         try {
             WSO2IS7RoleInfo role = wso2IS7SCIMRolesClient.getRole(roleId);
             List<Map<String, String>> permissions = role.getPermissions();
+
+            if (permissions == null) {
+                permissions = Collections.emptyList();
+            }
+
+            // Skip if this role already has the scope
+            if (permissions.stream().anyMatch(p -> scope.getKey().equals(p.get("value")))) {
+                return;
+            }
 
             List<WSO2IS7PatchRoleOperationInfo.Permission> allPermissions = new ArrayList<>();
             for (Map<String, String> existingPermission : permissions) {
@@ -1609,13 +1664,17 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
             throws APIManagementException {
 
         String wso2IS7APIResourceId = getWSO2IS7APIResourceId();
-        // Remove the old local scopes
+        Set<String> newLocalScopeKeys = newLocalScopes.stream().map(Scope::getKey).collect(Collectors.toSet());
+        Set<String> removedScopeKeys = new HashSet<>(oldLocalScopeKeys);
+        removedScopeKeys.removeAll(newLocalScopeKeys);
+
+        // Remove only scopes that are no longer present after update.
         if (wso2IS7APIResourceId != null) {
-            for (String oldScope : oldLocalScopeKeys) {
+            for (String removedScope : removedScopeKeys) {
                 try {
-                    wso2IS7APIResourceManagementClient.deleteScopeFromAPIResource(wso2IS7APIResourceId, oldScope);
+                    wso2IS7APIResourceManagementClient.deleteScopeFromAPIResource(wso2IS7APIResourceId, removedScope);
                 } catch (KeyManagerClientException e) {
-                    handleException("Failed to delete scope: " + oldScope + " from WSO2 IS7 API Resource: " +
+                    handleException("Failed to delete scope: " + removedScope + " from WSO2 IS7 API Resource: " +
                             DEFAULT_OAUTH_2_RESOURCE_IDENTIFIER, e);
                 }
             }
@@ -1719,6 +1778,9 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
                 if (roleId != null) {
                     WSO2IS7RoleInfo roleInfo = wso2IS7SCIMRolesClient.getRole(roleId);
                     List<Map<String, String>> existingScopes = roleInfo.getPermissions();
+                    if (existingScopes == null) {
+                        existingScopes = Collections.emptyList();
+                    }
 
                     // Update the role with all the existing scopes(permissions) except the given scope(permission)
                     List<WSO2IS7PatchRoleOperationInfo.Permission> permissions = new ArrayList<>();


### PR DESCRIPTION
## Purpose

This PR fixes an issue where application-level scope authorizations configured in WSO2 IS 7.x disappear after redeploying/updating an API from API Manager.

Previously, during API updates/redeployments, all local scopes associated with the API resource were removed and recreated in WSO2 IS 7.x regardless of whether the scope definitions had actually changed. Since application-level API authorizations in IS are associated with the underlying scope identity, deleting and recreating scopes caused existing `application ↔ scope` mappings to be lost.

## Approach

- Preserve existing scopes during API redeployment/update instead of deleting and recreating all scopes.
- Remove only scopes that are no longer present in the updated API definition.
- Update existing scope metadata (display name and description) in-place using patch operations.
- Update scope-role bindings by removing stale roles when existing roles are removed from existing scope
- Fix scope existence detection to use scope key instead of display name

**Previous Behaviour**
Api resource update/redeploy -->Delete all scopes -->Recreate scopes --> New internal scope identities created--> Existing application scope authorizations lost

**Fixed behaviour**
Api resource update/redeploy --> Existing scopes preserved --> Only newly added scopes created --> Only removed scopes deleted --> Existing scope metadata/role bindings patched if changed

## Related issues

- Fixes https://github.com/wso2/api-manager/issues/5034