### PR TITLE
Add unit tests for RoleBasedScopesIssuer scope filtering refactor

### DIFF
--- a/components/wso2is.key.manager.core/pom.xml
+++ b/components/wso2is.key.manager.core/pom.xml
@@ -99,5 +99,25 @@
             <groupId>org.wso2.orbit.com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/carbon/apimgt/impl/issuers/SystemScopesIssuer.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/carbon/apimgt/impl/issuers/SystemScopesIssuer.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.apimgt.impl.issuers;
+
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.validators.OAuth2TokenValidationMessageContext;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
+
+/**
+ * Test stub that mirrors the fully qualified name of the real
+ * {@code org.wso2.carbon.apimgt.impl.issuers.SystemScopesIssuer}. It exists purely so that
+ * {@code RoleBasedScopesIssuer.isSystemScopeIssuerAvailable()} (which matches scope validators by class name)
+ * can be exercised without pulling in the APIM impl bundle.
+ */
+public class SystemScopesIssuer implements ScopeValidator {
+
+    @Override
+    public boolean validateScope(OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext) {
+
+        return true;
+    }
+
+    @Override
+    public boolean validateScope(OAuthTokenReqMessageContext oAuthTokenReqMessageContext) {
+
+        return true;
+    }
+
+    @Override
+    public boolean validateScope(OAuth2TokenValidationMessageContext oAuth2TokenValidationMessageContext) {
+
+        return true;
+    }
+
+    @Override
+    public String getName() {
+
+        return "SystemScopesIssuer";
+    }
+}

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponentTest.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponentTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.is.key.manager.core.internal;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
+
+import java.util.List;
+
+/**
+ * Unit tests for the {@code scope.validator.service} bind/unbind methods added to
+ * {@link KeyManagerCoreServiceComponent}.
+ */
+public class KeyManagerCoreServiceComponentTest {
+
+    private KeyManagerCoreServiceComponent component;
+
+    @Before
+    public void init() {
+
+        component = new KeyManagerCoreServiceComponent();
+        ServiceReferenceHolder.getInstance().getScopeValidators().clear();
+    }
+
+    @After
+    public void cleanup() {
+
+        ServiceReferenceHolder.getInstance().getScopeValidators().clear();
+    }
+
+    @Test
+    public void testAddScopeValidatorService() throws Exception {
+
+        ScopeValidator validator = Mockito.mock(ScopeValidator.class);
+        Mockito.when(validator.getName()).thenReturn("Test scope validator");
+
+        Whitebox.invokeMethod(component, "addScopeValidatorService", validator);
+
+        List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
+        Assert.assertEquals(1, validators.size());
+        Assert.assertTrue(validators.contains(validator));
+    }
+
+    @Test
+    public void testRemoveScopeValidatorService() throws Exception {
+
+        ScopeValidator validator = Mockito.mock(ScopeValidator.class);
+        Mockito.when(validator.getName()).thenReturn("Test scope validator");
+
+        Whitebox.invokeMethod(component, "addScopeValidatorService", validator);
+        Whitebox.invokeMethod(component, "removeScopeValidatorService", validator);
+
+        Assert.assertTrue(ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
+    }
+}

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponentTest.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponentTest.java
@@ -57,8 +57,9 @@ public class KeyManagerCoreServiceComponentTest {
         Whitebox.invokeMethod(component, "addScopeValidatorService", validator);
 
         List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
-        Assert.assertEquals(1, validators.size());
-        Assert.assertTrue(validators.contains(validator));
+        Assert.assertEquals("Binding a scope validator service should register exactly one validator; got "
+                + validators, 1, validators.size());
+        Assert.assertTrue("Bound validator should be present in the registry", validators.contains(validator));
     }
 
     @Test
@@ -70,6 +71,7 @@ public class KeyManagerCoreServiceComponentTest {
         Whitebox.invokeMethod(component, "addScopeValidatorService", validator);
         Whitebox.invokeMethod(component, "removeScopeValidatorService", validator);
 
-        Assert.assertTrue(ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
+        Assert.assertTrue("Unbinding the scope validator service should leave the registry empty",
+                ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
     }
 }

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolderTest.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolderTest.java
@@ -50,8 +50,9 @@ public class ServiceReferenceHolderTest {
         ServiceReferenceHolder.getInstance().addScopeValidator(validator);
 
         List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
-        Assert.assertEquals(1, validators.size());
-        Assert.assertTrue(validators.contains(validator));
+        Assert.assertEquals("Registry should hold exactly one validator after a single add; got " + validators,
+                1, validators.size());
+        Assert.assertTrue("Added validator should be present in the registry", validators.contains(validator));
     }
 
     @Test
@@ -63,9 +64,9 @@ public class ServiceReferenceHolderTest {
         ServiceReferenceHolder.getInstance().addScopeValidator(validator2);
 
         List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
-        Assert.assertEquals(2, validators.size());
-        Assert.assertTrue(validators.contains(validator1));
-        Assert.assertTrue(validators.contains(validator2));
+        Assert.assertEquals("Registry should hold both added validators; got " + validators, 2, validators.size());
+        Assert.assertTrue("First added validator should be present", validators.contains(validator1));
+        Assert.assertTrue("Second added validator should be present", validators.contains(validator2));
     }
 
     @Test
@@ -79,15 +80,17 @@ public class ServiceReferenceHolderTest {
         ServiceReferenceHolder.getInstance().removeScopeValidator(validator1);
 
         List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
-        Assert.assertEquals(1, validators.size());
-        Assert.assertFalse(validators.contains(validator1));
-        Assert.assertTrue(validators.contains(validator2));
+        Assert.assertEquals("Registry should hold one validator after removing one of two; got " + validators,
+                1, validators.size());
+        Assert.assertFalse("Removed validator should no longer be present", validators.contains(validator1));
+        Assert.assertTrue("Remaining validator should still be present", validators.contains(validator2));
     }
 
     @Test
     public void testGetScopeValidatorsInitiallyEmpty() {
 
-        Assert.assertTrue(ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
+        Assert.assertTrue("A freshly cleared registry should report empty",
+                ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
     }
 
     @Test
@@ -96,6 +99,7 @@ public class ServiceReferenceHolderTest {
         ScopeValidator validator = Mockito.mock(ScopeValidator.class);
         ServiceReferenceHolder.getInstance().removeScopeValidator(validator);
 
-        Assert.assertTrue(ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
+        Assert.assertTrue("Removing a validator that was never added should be a no-op and leave the registry empty",
+                ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
     }
 }

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolderTest.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolderTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.is.key.manager.core.internal;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
+
+import java.util.List;
+
+/**
+ * Unit tests for the scope-validator registry added to {@link ServiceReferenceHolder}.
+ */
+public class ServiceReferenceHolderTest {
+
+    @Before
+    public void init() {
+
+        ServiceReferenceHolder.getInstance().getScopeValidators().clear();
+    }
+
+    @After
+    public void cleanup() {
+
+        ServiceReferenceHolder.getInstance().getScopeValidators().clear();
+    }
+
+    @Test
+    public void testAddScopeValidator() {
+
+        ScopeValidator validator = Mockito.mock(ScopeValidator.class);
+        ServiceReferenceHolder.getInstance().addScopeValidator(validator);
+
+        List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
+        Assert.assertEquals(1, validators.size());
+        Assert.assertTrue(validators.contains(validator));
+    }
+
+    @Test
+    public void testAddMultipleScopeValidators() {
+
+        ScopeValidator validator1 = Mockito.mock(ScopeValidator.class);
+        ScopeValidator validator2 = Mockito.mock(ScopeValidator.class);
+        ServiceReferenceHolder.getInstance().addScopeValidator(validator1);
+        ServiceReferenceHolder.getInstance().addScopeValidator(validator2);
+
+        List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
+        Assert.assertEquals(2, validators.size());
+        Assert.assertTrue(validators.contains(validator1));
+        Assert.assertTrue(validators.contains(validator2));
+    }
+
+    @Test
+    public void testRemoveScopeValidator() {
+
+        ScopeValidator validator1 = Mockito.mock(ScopeValidator.class);
+        ScopeValidator validator2 = Mockito.mock(ScopeValidator.class);
+        ServiceReferenceHolder.getInstance().addScopeValidator(validator1);
+        ServiceReferenceHolder.getInstance().addScopeValidator(validator2);
+
+        ServiceReferenceHolder.getInstance().removeScopeValidator(validator1);
+
+        List<ScopeValidator> validators = ServiceReferenceHolder.getInstance().getScopeValidators();
+        Assert.assertEquals(1, validators.size());
+        Assert.assertFalse(validators.contains(validator1));
+        Assert.assertTrue(validators.contains(validator2));
+    }
+
+    @Test
+    public void testGetScopeValidatorsInitiallyEmpty() {
+
+        Assert.assertTrue(ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
+    }
+
+    @Test
+    public void testRemoveScopeValidatorNotPresentIsNoOp() {
+
+        ScopeValidator validator = Mockito.mock(ScopeValidator.class);
+        ServiceReferenceHolder.getInstance().removeScopeValidator(validator);
+
+        Assert.assertTrue(ServiceReferenceHolder.getInstance().getScopeValidators().isEmpty());
+    }
+}

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuerTest.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuerTest.java
@@ -118,16 +118,26 @@ public class RoleBasedScopesIssuerTest {
     }
 
     @Test
-    public void testAuthzProductScopesPassThroughWhenSystemIssuerAvailable() {
+    public void testAuthzProductScopesPassThroughWhenSystemIssuerAvailable() throws Exception {
 
         registerSystemScopesIssuer();
+        // When the pass-through works, requestedScopes is emptied and the method returns before getAppScopes is
+        // reached; this stub only takes effect if the (regressed) code falls through, yielding a clean assertion
+        // failure instead of a NoClassDefFoundError from real infrastructure.
+        PowerMockito.doReturn(null).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
         OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2});
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_1
+                + " should pass through to SystemScopesIssuer when one is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_2
+                + " should pass through to SystemScopesIssuer when one is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_2));
+        Assert.assertEquals("Only the two requested product scopes should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -138,8 +148,10 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = scopesIssuer.getScopes(context);
 
         // No SystemScopesIssuer: product scopes are dropped and requestedScopes becomes empty -> default scope.
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+        Assert.assertEquals("Without a SystemScopesIssuer, product scopes are dropped leaving only the default "
+                + "scope; got " + result, 1, result.size());
+        Assert.assertTrue("Result should fall back to the default scope " + DEFAULT_SCOPE + "; got " + result,
+                result.contains(DEFAULT_SCOPE));
     }
 
     @Test
@@ -153,9 +165,12 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = scopesIssuer.getScopes(context);
 
         // Product scope passes through, app scope passes through the empty-app-scopes branch.
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(APP_SCOPE));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_1 + " should pass through with a SystemScopesIssuer; got "
+                + result, result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("App scope " + APP_SCOPE + " should be retained; got " + result,
+                result.contains(APP_SCOPE));
+        Assert.assertEquals("Both the product scope and the app scope should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -168,9 +183,12 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = scopesIssuer.getScopes(context);
 
         // Product scope dropped, only the app scope remains.
-        Assert.assertFalse(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(APP_SCOPE));
-        Assert.assertEquals(1, result.size());
+        Assert.assertFalse("Product scope " + PRODUCT_SCOPE_1
+                + " should be dropped without a SystemScopesIssuer; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("App scope " + APP_SCOPE + " should be retained; got " + result,
+                result.contains(APP_SCOPE));
+        Assert.assertEquals("Only the app scope should remain; got " + result, 1, result.size());
     }
 
     @Test
@@ -187,7 +205,8 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertTrue(result.isEmpty());
+        Assert.assertTrue("A null approved scope should yield no authorized scopes; got " + result,
+                result.isEmpty());
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -195,19 +214,26 @@ public class RoleBasedScopesIssuerTest {
     // ------------------------------------------------------------------------------------------------
 
     @Test
-    public void testRestrictFlagsDoNotGateProductScopesWhenSystemIssuerAvailable() {
+    public void testRestrictFlagsDoNotGateProductScopesWhenSystemIssuerAvailable() throws Exception {
 
         // Both restrict flags ON used to suppress product scope pass-through; now only the SystemScopesIssuer matters.
         ServiceReferenceHolder.setRestrictUnassignedScopes(true);
         ServiceReferenceHolder.setRestrictApimRestApiScopes(true);
         registerSystemScopesIssuer();
+        PowerMockito.doReturn(null).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
         OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_3});
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_3));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("restrict.* flags must not gate pass-through; product scope " + PRODUCT_SCOPE_1
+                + " should pass through when a SystemScopesIssuer is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("restrict.* flags must not gate pass-through; product scope " + PRODUCT_SCOPE_3
+                + " should pass through when a SystemScopesIssuer is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_3));
+        Assert.assertEquals("Only the two requested product scopes should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -221,10 +247,15 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertFalse(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertFalse(result.contains(PRODUCT_SCOPE_3));
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+        Assert.assertFalse("Without a SystemScopesIssuer, product scope " + PRODUCT_SCOPE_1
+                + " should be dropped regardless of the restrict.* flags; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertFalse("Without a SystemScopesIssuer, product scope " + PRODUCT_SCOPE_3
+                + " should be dropped regardless of the restrict.* flags; got " + result,
+                result.contains(PRODUCT_SCOPE_3));
+        Assert.assertEquals("Only the default scope should remain; got " + result, 1, result.size());
+        Assert.assertTrue("Result should fall back to the default scope " + DEFAULT_SCOPE + "; got " + result,
+                result.contains(DEFAULT_SCOPE));
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -241,16 +272,23 @@ public class RoleBasedScopesIssuerTest {
     }
 
     @Test
-    public void testCallbackProductScopesPassThroughWhenSystemIssuerAvailable() {
+    public void testCallbackProductScopesPassThroughWhenSystemIssuerAvailable() throws Exception {
 
         registerSystemScopesIssuer();
+        PowerMockito.doReturn(null).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
         OAuthCallback callback = mockCallback(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2});
 
         List<String> result = scopesIssuer.getScopes(callback);
 
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_1
+                + " should pass through (OAuthCallback) when a SystemScopesIssuer is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_2
+                + " should pass through (OAuthCallback) when a SystemScopesIssuer is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_2));
+        Assert.assertEquals("Only the two requested product scopes should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -260,8 +298,10 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(callback);
 
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+        Assert.assertEquals("Without a SystemScopesIssuer (OAuthCallback), product scopes are dropped leaving only "
+                + "the default scope; got " + result, 1, result.size());
+        Assert.assertTrue("Result should fall back to the default scope " + DEFAULT_SCOPE + "; got " + result,
+                result.contains(DEFAULT_SCOPE));
     }
 
     @Test
@@ -274,9 +314,13 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(callback);
 
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
-        Assert.assertTrue(result.contains(APP_SCOPE));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_2
+                + " should pass through (OAuthCallback) with a SystemScopesIssuer; got " + result,
+                result.contains(PRODUCT_SCOPE_2));
+        Assert.assertTrue("App scope " + APP_SCOPE + " should be retained; got " + result,
+                result.contains(APP_SCOPE));
+        Assert.assertEquals("Both the product scope and the app scope should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -288,9 +332,12 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(callback);
 
-        Assert.assertFalse(result.contains(PRODUCT_SCOPE_2));
-        Assert.assertTrue(result.contains(APP_SCOPE));
-        Assert.assertEquals(1, result.size());
+        Assert.assertFalse("Product scope " + PRODUCT_SCOPE_2
+                + " should be dropped (OAuthCallback) without a SystemScopesIssuer; got " + result,
+                result.contains(PRODUCT_SCOPE_2));
+        Assert.assertTrue("App scope " + APP_SCOPE + " should be retained; got " + result,
+                result.contains(APP_SCOPE));
+        Assert.assertEquals("Only the app scope should remain; got " + result, 1, result.size());
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -310,17 +357,24 @@ public class RoleBasedScopesIssuerTest {
     }
 
     @Test
-    public void testTokenProductScopesPassThroughWhenSystemIssuerAvailable() {
+    public void testTokenProductScopesPassThroughWhenSystemIssuerAvailable() throws Exception {
 
         registerSystemScopesIssuer();
+        PowerMockito.doReturn(null).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
         OAuthTokenReqMessageContext context =
                 mockTokenContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2}, "authorization_code");
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_1
+                + " should pass through (token flow) when a SystemScopesIssuer is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_2
+                + " should pass through (token flow) when a SystemScopesIssuer is registered; got " + result,
+                result.contains(PRODUCT_SCOPE_2));
+        Assert.assertEquals("Only the two requested product scopes should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -331,8 +385,10 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+        Assert.assertEquals("Without a SystemScopesIssuer (token flow), product scopes are dropped leaving only "
+                + "the default scope; got " + result, 1, result.size());
+        Assert.assertTrue("Result should fall back to the default scope " + DEFAULT_SCOPE + "; got " + result,
+                result.contains(DEFAULT_SCOPE));
     }
 
     @Test
@@ -346,9 +402,13 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(APP_SCOPE));
-        Assert.assertEquals(2, result.size());
+        Assert.assertTrue("Product scope " + PRODUCT_SCOPE_1
+                + " should pass through (token flow) with a SystemScopesIssuer; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("App scope " + APP_SCOPE + " should be retained; got " + result,
+                result.contains(APP_SCOPE));
+        Assert.assertEquals("Both the product scope and the app scope should be returned; got " + result,
+                2, result.size());
     }
 
     @Test
@@ -361,9 +421,12 @@ public class RoleBasedScopesIssuerTest {
 
         List<String> result = scopesIssuer.getScopes(context);
 
-        Assert.assertFalse(result.contains(PRODUCT_SCOPE_1));
-        Assert.assertTrue(result.contains(APP_SCOPE));
-        Assert.assertEquals(1, result.size());
+        Assert.assertFalse("Product scope " + PRODUCT_SCOPE_1
+                + " should be dropped (token flow) without a SystemScopesIssuer; got " + result,
+                result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue("App scope " + APP_SCOPE + " should be retained; got " + result,
+                result.contains(APP_SCOPE));
+        Assert.assertEquals("Only the app scope should remain; got " + result, 1, result.size());
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -375,14 +438,16 @@ public class RoleBasedScopesIssuerTest {
 
         registerSystemScopesIssuer();
         boolean available = Whitebox.invokeMethod(scopesIssuer, "isSystemScopeIssuerAvailable");
-        Assert.assertTrue(available);
+        Assert.assertTrue("isSystemScopeIssuerAvailable() should return true when a SystemScopesIssuer is registered",
+                available);
     }
 
     @Test
     public void testIsSystemScopeIssuerAvailableFalseWhenEmpty() throws Exception {
 
         boolean available = Whitebox.invokeMethod(scopesIssuer, "isSystemScopeIssuerAvailable");
-        Assert.assertFalse(available);
+        Assert.assertFalse("isSystemScopeIssuerAvailable() should return false when no validators are registered",
+                available);
     }
 
     @Test
@@ -393,7 +458,8 @@ public class RoleBasedScopesIssuerTest {
         ServiceReferenceHolder.getInstance().addScopeValidator(new RoleBasedScopesIssuer());
 
         boolean available = Whitebox.invokeMethod(scopesIssuer, "isSystemScopeIssuerAvailable");
-        Assert.assertFalse(available);
+        Assert.assertFalse("isSystemScopeIssuerAvailable() should return false when only non-SystemScopesIssuer "
+                + "validators are registered", available);
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -416,9 +482,11 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
                 userRoles, requestedScopes, appScopes);
 
-        Assert.assertTrue(result.contains("app_scope"));
-        Assert.assertTrue(result.contains("whitelisted_scope"));
-        Assert.assertFalse(result.contains("unassigned_scope"));
+        Assert.assertTrue("App scope should be authorized; got " + result, result.contains("app_scope"));
+        Assert.assertTrue("Whitelisted scope should be authorized; got " + result,
+                result.contains("whitelisted_scope"));
+        Assert.assertFalse("Unassigned scope must be filtered when restrict.unassigned.scopes is on; got " + result,
+                result.contains("unassigned_scope"));
     }
 
     @Test
@@ -434,8 +502,9 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
                 userRoles, requestedScopes, appScopes);
 
-        Assert.assertTrue(result.contains("app_scope"));
-        Assert.assertTrue(result.contains("unassigned_scope"));
+        Assert.assertTrue("App scope should be authorized; got " + result, result.contains("app_scope"));
+        Assert.assertTrue("Unassigned scope should be allowed when restrict.unassigned.scopes is off; got " + result,
+                result.contains("unassigned_scope"));
     }
 
     @Test
@@ -452,7 +521,8 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
                 userRoles, requestedScopes, appScopes);
 
-        Assert.assertTrue(result.contains("scope1"));
+        Assert.assertTrue("With preservedCaseSensitive off, role 'admin' should match scope role 'Admin'; got "
+                + result, result.contains("scope1"));
     }
 
     @Test
@@ -469,7 +539,9 @@ public class RoleBasedScopesIssuerTest {
         List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
                 userRoles, requestedScopes, appScopes);
 
-        Assert.assertFalse(result.contains("scope1"));
-        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+        Assert.assertFalse("With preservedCaseSensitive on, role 'admin' should not match scope role 'Admin'; got "
+                + result, result.contains("scope1"));
+        Assert.assertTrue("Result should fall back to the default scope " + DEFAULT_SCOPE + "; got " + result,
+                result.contains(DEFAULT_SCOPE));
     }
 }

--- a/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuerTest.java
+++ b/components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/tokenmgt/issuers/RoleBasedScopesIssuerTest.java
@@ -1,0 +1,475 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.is.key.manager.core.tokenmgt.issuers;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+import org.wso2.carbon.apimgt.impl.issuers.SystemScopesIssuer;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.oauth.callback.OAuthCallback;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
+import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenReqDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2AuthorizeReqDTO;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.validators.scope.ScopeValidator;
+import org.wso2.is.key.manager.core.internal.ServiceReferenceHolder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests covering the scope-filtering refactor in {@link RoleBasedScopesIssuer}.
+ *
+ * The behavior under test is the product REST API scope (apim:, apim_analytics:, service_catalog:) pass-through,
+ * which is now gated solely by the presence of a registered {@code SystemScopesIssuer} scope validator
+ * (via {@code isSystemScopeIssuerAvailable()}) instead of the {@code restrict.unassigned.scopes} and
+ * {@code restrict.apim.restapi.scopes} system-property flags. The related system-property scenarios
+ * ({@code restrict.unassigned.scopes} in {@code getAuthorizedScopes} and {@code preservedCaseSensitive}) are
+ * covered as well.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({OAuthServerConfiguration.class})
+public class RoleBasedScopesIssuerTest {
+
+    private static final String PRESERVED_CASE_SENSITIVE_VARIABLE = "preservedCaseSensitive";
+    private static final String PRODUCT_SCOPE_1 = "apim:api_view";
+    private static final String PRODUCT_SCOPE_2 = "service_catalog:view";
+    private static final String PRODUCT_SCOPE_3 = "apim_analytics:view";
+    private static final String APP_SCOPE = "scope_internal";
+    private static final String DEFAULT_SCOPE = "default";
+
+    private RoleBasedScopesIssuer scopesIssuer;
+    private List<String> allowedScopes;
+
+    @Before
+    public void init() throws Exception {
+
+        // Mock the OAuthServerConfiguration singleton so constructing the issuer does not load real server config.
+        PowerMockito.mockStatic(OAuthServerConfiguration.class);
+        OAuthServerConfiguration oAuthServerConfiguration = Mockito.mock(OAuthServerConfiguration.class);
+        PowerMockito.when(OAuthServerConfiguration.getInstance()).thenReturn(oAuthServerConfiguration);
+        allowedScopes = new ArrayList<>();
+        Mockito.when(oAuthServerConfiguration.getAllowedScopes()).thenReturn(allowedScopes);
+
+        scopesIssuer = PowerMockito.spy(new RoleBasedScopesIssuer());
+
+        // Start every test from a clean shared-state baseline.
+        ServiceReferenceHolder.getInstance().getScopeValidators().clear();
+        ServiceReferenceHolder.setRestrictUnassignedScopes(false);
+        ServiceReferenceHolder.setRestrictApimRestApiScopes(false);
+        System.clearProperty(PRESERVED_CASE_SENSITIVE_VARIABLE);
+    }
+
+    @After
+    public void cleanup() {
+
+        ServiceReferenceHolder.getInstance().getScopeValidators().clear();
+        ServiceReferenceHolder.setRestrictUnassignedScopes(false);
+        ServiceReferenceHolder.setRestrictApimRestApiScopes(false);
+        System.clearProperty(PRESERVED_CASE_SENSITIVE_VARIABLE);
+    }
+
+    private void registerSystemScopesIssuer() {
+
+        ServiceReferenceHolder.getInstance().addScopeValidator(new SystemScopesIssuer());
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // getScopes(OAuthAuthzReqMessageContext)
+    // ------------------------------------------------------------------------------------------------
+
+    private OAuthAuthzReqMessageContext mockAuthzContext(String[] approvedScopes) {
+
+        OAuthAuthzReqMessageContext context = Mockito.mock(OAuthAuthzReqMessageContext.class);
+        OAuth2AuthorizeReqDTO authorizeReqDTO = Mockito.mock(OAuth2AuthorizeReqDTO.class);
+        AuthenticatedUser user = Mockito.mock(AuthenticatedUser.class);
+        Mockito.when(context.getApprovedScope()).thenReturn(approvedScopes);
+        Mockito.when(context.getAuthorizationReqDTO()).thenReturn(authorizeReqDTO);
+        Mockito.when(authorizeReqDTO.getConsumerKey()).thenReturn("client-1");
+        Mockito.when(authorizeReqDTO.getUser()).thenReturn(user);
+        return context;
+    }
+
+    @Test
+    public void testAuthzProductScopesPassThroughWhenSystemIssuerAvailable() {
+
+        registerSystemScopesIssuer();
+        OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2});
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testAuthzProductScopesDroppedWhenSystemIssuerNotAvailable() {
+
+        OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2});
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        // No SystemScopesIssuer: product scopes are dropped and requestedScopes becomes empty -> default scope.
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+    }
+
+    @Test
+    public void testAuthzMixedScopesWithSystemIssuer() throws Exception {
+
+        registerSystemScopesIssuer();
+        PowerMockito.doReturn(new HashMap<String, String>()).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
+        OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, APP_SCOPE});
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        // Product scope passes through, app scope passes through the empty-app-scopes branch.
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(APP_SCOPE));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testAuthzMixedScopesWithoutSystemIssuer() throws Exception {
+
+        PowerMockito.doReturn(new HashMap<String, String>()).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
+        OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, APP_SCOPE});
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        // Product scope dropped, only the app scope remains.
+        Assert.assertFalse(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(APP_SCOPE));
+        Assert.assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testAuthzNullApprovedScope() throws Exception {
+
+        OAuthAuthzReqMessageContext context = Mockito.mock(OAuthAuthzReqMessageContext.class);
+        OAuth2AuthorizeReqDTO authorizeReqDTO = Mockito.mock(OAuth2AuthorizeReqDTO.class);
+        Mockito.when(context.getApprovedScope()).thenReturn(null);
+        Mockito.when(context.getAuthorizationReqDTO()).thenReturn(authorizeReqDTO);
+        Mockito.when(authorizeReqDTO.getConsumerKey()).thenReturn("client-1");
+        Mockito.when(authorizeReqDTO.getUser()).thenReturn(Mockito.mock(AuthenticatedUser.class));
+        PowerMockito.doReturn(null).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.any());
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // Regression: restrict.* flags no longer gate product REST API scope pass-through (option 1)
+    // ------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testRestrictFlagsDoNotGateProductScopesWhenSystemIssuerAvailable() {
+
+        // Both restrict flags ON used to suppress product scope pass-through; now only the SystemScopesIssuer matters.
+        ServiceReferenceHolder.setRestrictUnassignedScopes(true);
+        ServiceReferenceHolder.setRestrictApimRestApiScopes(true);
+        registerSystemScopesIssuer();
+        OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_3});
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_3));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testRestrictFlagsDoNotForceProductScopesWhenSystemIssuerNotAvailable() {
+
+        // Both restrict flags OFF used to force product scope pass-through; now the absence of the SystemScopesIssuer
+        // drops them regardless of the flags.
+        ServiceReferenceHolder.setRestrictUnassignedScopes(false);
+        ServiceReferenceHolder.setRestrictApimRestApiScopes(false);
+        OAuthAuthzReqMessageContext context = mockAuthzContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_3});
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertFalse(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertFalse(result.contains(PRODUCT_SCOPE_3));
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // getScopes(OAuthCallback)
+    // ------------------------------------------------------------------------------------------------
+
+    private OAuthCallback mockCallback(String[] requestedScopes) {
+
+        OAuthCallback callback = Mockito.mock(OAuthCallback.class);
+        Mockito.when(callback.getRequestedScope()).thenReturn(requestedScopes);
+        Mockito.when(callback.getClient()).thenReturn("client-1");
+        Mockito.when(callback.getResourceOwner()).thenReturn(Mockito.mock(AuthenticatedUser.class));
+        return callback;
+    }
+
+    @Test
+    public void testCallbackProductScopesPassThroughWhenSystemIssuerAvailable() {
+
+        registerSystemScopesIssuer();
+        OAuthCallback callback = mockCallback(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2});
+
+        List<String> result = scopesIssuer.getScopes(callback);
+
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testCallbackProductScopesDroppedWhenSystemIssuerNotAvailable() {
+
+        OAuthCallback callback = mockCallback(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2});
+
+        List<String> result = scopesIssuer.getScopes(callback);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+    }
+
+    @Test
+    public void testCallbackMixedScopesWithSystemIssuer() throws Exception {
+
+        registerSystemScopesIssuer();
+        PowerMockito.doReturn(new HashMap<String, String>()).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
+        OAuthCallback callback = mockCallback(new String[]{PRODUCT_SCOPE_2, APP_SCOPE});
+
+        List<String> result = scopesIssuer.getScopes(callback);
+
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
+        Assert.assertTrue(result.contains(APP_SCOPE));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testCallbackMixedScopesWithoutSystemIssuer() throws Exception {
+
+        PowerMockito.doReturn(new HashMap<String, String>()).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
+        OAuthCallback callback = mockCallback(new String[]{PRODUCT_SCOPE_2, APP_SCOPE});
+
+        List<String> result = scopesIssuer.getScopes(callback);
+
+        Assert.assertFalse(result.contains(PRODUCT_SCOPE_2));
+        Assert.assertTrue(result.contains(APP_SCOPE));
+        Assert.assertEquals(1, result.size());
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // getScopes(OAuthTokenReqMessageContext)
+    // ------------------------------------------------------------------------------------------------
+
+    private OAuthTokenReqMessageContext mockTokenContext(String[] requestedScopes, String grantType) {
+
+        OAuthTokenReqMessageContext context = Mockito.mock(OAuthTokenReqMessageContext.class);
+        OAuth2AccessTokenReqDTO tokenReqDTO = Mockito.mock(OAuth2AccessTokenReqDTO.class);
+        Mockito.when(context.getScope()).thenReturn(requestedScopes);
+        Mockito.when(context.getOauth2AccessTokenReqDTO()).thenReturn(tokenReqDTO);
+        Mockito.when(context.getAuthorizedUser()).thenReturn(Mockito.mock(AuthenticatedUser.class));
+        Mockito.when(tokenReqDTO.getClientId()).thenReturn("client-1");
+        Mockito.when(tokenReqDTO.getGrantType()).thenReturn(grantType);
+        return context;
+    }
+
+    @Test
+    public void testTokenProductScopesPassThroughWhenSystemIssuerAvailable() {
+
+        registerSystemScopesIssuer();
+        OAuthTokenReqMessageContext context =
+                mockTokenContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2}, "authorization_code");
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_2));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testTokenProductScopesDroppedWhenSystemIssuerNotAvailable() {
+
+        OAuthTokenReqMessageContext context =
+                mockTokenContext(new String[]{PRODUCT_SCOPE_1, PRODUCT_SCOPE_2}, "authorization_code");
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+    }
+
+    @Test
+    public void testTokenMixedScopesWithSystemIssuer() throws Exception {
+
+        registerSystemScopesIssuer();
+        PowerMockito.doReturn(new HashMap<String, String>()).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
+        OAuthTokenReqMessageContext context =
+                mockTokenContext(new String[]{PRODUCT_SCOPE_1, APP_SCOPE}, "authorization_code");
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertTrue(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(APP_SCOPE));
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testTokenMixedScopesWithoutSystemIssuer() throws Exception {
+
+        PowerMockito.doReturn(new HashMap<String, String>()).when(scopesIssuer)
+                .getAppScopes(Mockito.anyString(), Mockito.any(AuthenticatedUser.class), Mockito.anyList());
+        OAuthTokenReqMessageContext context =
+                mockTokenContext(new String[]{PRODUCT_SCOPE_1, APP_SCOPE}, "authorization_code");
+
+        List<String> result = scopesIssuer.getScopes(context);
+
+        Assert.assertFalse(result.contains(PRODUCT_SCOPE_1));
+        Assert.assertTrue(result.contains(APP_SCOPE));
+        Assert.assertEquals(1, result.size());
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // isSystemScopeIssuerAvailable()
+    // ------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testIsSystemScopeIssuerAvailableTrue() throws Exception {
+
+        registerSystemScopesIssuer();
+        boolean available = Whitebox.invokeMethod(scopesIssuer, "isSystemScopeIssuerAvailable");
+        Assert.assertTrue(available);
+    }
+
+    @Test
+    public void testIsSystemScopeIssuerAvailableFalseWhenEmpty() throws Exception {
+
+        boolean available = Whitebox.invokeMethod(scopesIssuer, "isSystemScopeIssuerAvailable");
+        Assert.assertFalse(available);
+    }
+
+    @Test
+    public void testIsSystemScopeIssuerAvailableFalseWithOtherValidator() throws Exception {
+
+        // A different validator (e.g. RoleBasedScopesIssuer itself) must not be mistaken for the SystemScopesIssuer.
+        ServiceReferenceHolder.getInstance().addScopeValidator(Mockito.mock(ScopeValidator.class));
+        ServiceReferenceHolder.getInstance().addScopeValidator(new RoleBasedScopesIssuer());
+
+        boolean available = Whitebox.invokeMethod(scopesIssuer, "isSystemScopeIssuerAvailable");
+        Assert.assertFalse(available);
+    }
+
+    // ------------------------------------------------------------------------------------------------
+    // getAuthorizedScopes() - related system-property scenarios (options 2 and 3)
+    // ------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testRestrictUnassignedScopesFiltersUnassignedScopes() throws Exception {
+
+        // option 2: restrict.unassigned.scopes still filters scopes that are neither app scopes nor whitelisted.
+        ServiceReferenceHolder.setRestrictUnassignedScopes(true);
+        allowedScopes.add("whitelisted_scope");
+
+        Map<String, String> appScopes = new HashMap<>();
+        appScopes.put("app_scope", "");
+        String[] userRoles = new String[]{"admin"};
+        List<String> requestedScopes = new ArrayList<>(
+                Arrays.asList("app_scope", "unassigned_scope", "whitelisted_scope"));
+
+        List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
+                userRoles, requestedScopes, appScopes);
+
+        Assert.assertTrue(result.contains("app_scope"));
+        Assert.assertTrue(result.contains("whitelisted_scope"));
+        Assert.assertFalse(result.contains("unassigned_scope"));
+    }
+
+    @Test
+    public void testRestrictUnassignedScopesDisabledAllowsAllScopes() throws Exception {
+
+        ServiceReferenceHolder.setRestrictUnassignedScopes(false);
+
+        Map<String, String> appScopes = new HashMap<>();
+        appScopes.put("app_scope", "");
+        String[] userRoles = new String[]{"admin"};
+        List<String> requestedScopes = new ArrayList<>(Arrays.asList("app_scope", "unassigned_scope"));
+
+        List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
+                userRoles, requestedScopes, appScopes);
+
+        Assert.assertTrue(result.contains("app_scope"));
+        Assert.assertTrue(result.contains("unassigned_scope"));
+    }
+
+    @Test
+    public void testPreservedCaseSensitiveDisabledMatchesRolesCaseInsensitively() throws Exception {
+
+        // option 3: with preservedCaseSensitive off, role matching is case-insensitive.
+        System.clearProperty(PRESERVED_CASE_SENSITIVE_VARIABLE);
+
+        Map<String, String> appScopes = new HashMap<>();
+        appScopes.put("scope1", "Admin");
+        String[] userRoles = new String[]{"admin"};
+        List<String> requestedScopes = new ArrayList<>(Arrays.asList("scope1"));
+
+        List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
+                userRoles, requestedScopes, appScopes);
+
+        Assert.assertTrue(result.contains("scope1"));
+    }
+
+    @Test
+    public void testPreservedCaseSensitiveEnabledMatchesRolesCaseSensitively() throws Exception {
+
+        // option 3: with preservedCaseSensitive on, "admin" does not match the scope role "Admin" -> default scope.
+        System.setProperty(PRESERVED_CASE_SENSITIVE_VARIABLE, "true");
+
+        Map<String, String> appScopes = new HashMap<>();
+        appScopes.put("scope1", "Admin");
+        String[] userRoles = new String[]{"admin"};
+        List<String> requestedScopes = new ArrayList<>(Arrays.asList("scope1"));
+
+        List<String> result = Whitebox.invokeMethod(scopesIssuer, "getAuthorizedScopes",
+                userRoles, requestedScopes, appScopes);
+
+        Assert.assertFalse(result.contains("scope1"));
+        Assert.assertTrue(result.contains(DEFAULT_SCOPE));
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the new scope validator registry functionality and ensures the necessary test dependencies are available. The main changes include adding tests for `ServiceReferenceHolder` and `KeyManagerCoreServiceComponent`, as well as introducing a test stub for `SystemScopesIssuer`.

**Testing improvements:**

* Added `ServiceReferenceHolderTest` to verify adding, removing, and retrieving `ScopeValidator` instances in the registry (`components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/ServiceReferenceHolderTest.java`).
* Added `KeyManagerCoreServiceComponentTest` to test the bind and unbind methods for `ScopeValidator` services in `KeyManagerCoreServiceComponent` (`components/wso2is.key.manager.core/src/test/java/org/wso2/is/key/manager/core/internal/KeyManagerCoreServiceComponentTest.java`).

**Test infrastructure:**

* Added test dependencies (`junit`, `mockito-core`, `powermock-module-junit4`, `powermock-api-mockito2`) to the Maven configuration to support unit testing (`components/wso2is.key.manager.core/pom.xml`).
* Introduced a test stub for `SystemScopesIssuer` to allow testing of class name-based logic without depending on the actual APIM implementation (`components/wso2is.key.manager.core/src/test/java/org/wso2/carbon/apimgt/impl/issuers/SystemScopesIssuer.java`).

Related issue: https://github.com/wso2/api-manager/issues/4916