### PR TITLE
Fix callback URL update failure with external WSO2 IS 7 key manager

### DIFF
--- a/components/wso2is7.key.manager/pom.xml
+++ b/components/wso2is7.key.manager/pom.xml
@@ -141,7 +141,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/components/wso2is7.key.manager/pom.xml
+++ b/components/wso2is7.key.manager/pom.xml
@@ -133,5 +133,21 @@
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -727,7 +727,7 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
         if (appResponse.getRedirectUris() != null) {
             String callBackURL = buildCallbackURL(appResponse.getRedirectUris());
             oAuthApplicationInfo.setCallBackURL(callBackURL);
-            oAuthApplicationInfo.addParameter(ApplicationConstants.OAUTH_CALLBACK_URIS, callBackURL);
+            oAuthApplicationInfo.addParameter(ApplicationConstants.OAUTH_REDIRECT_URIS, callBackURL);
         }
         oAuthApplicationInfo.setClientSecret(appResponse.getClientSecret());
         if (appResponse.getGrantTypes() != null) {

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManager.java
@@ -256,6 +256,20 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
     }
 
     /**
+     * Splits a callback URL value into individual URLIs. Handles both a plain comma-separated list
+     * and the "regexp=(url1|url2)" pattern IS returns for apps with multiple callback URLs
+     */
+    private String[] extractCallbackURLs(String callBackURL) {
+        if (callBackURL.startsWith(WSO2IS7KeyManagerConstants.CALLBACK_URL_REGEXP_PREFIX)
+            && callBackURL.endsWith(")")) {
+            String urls = callBackURL.substring(WSO2IS7KeyManagerConstants.CALLBACK_URL_REGEXP_PREFIX.length(),
+                    callBackURL.length() - 1);
+            return urls.split("\\|");
+        }
+        return callBackURL.trim().split("\\s*,\\s*");
+    }
+
+    /**
      * Copied from AMDefaultKeyManagerImpl. WSO2IS7ClientInfo is used instead of ClientInfo.
      * Construct ClientInfo object for application create request
      *
@@ -282,8 +296,7 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
         }
         if (StringUtils.isNotEmpty(info.getCallBackURL())) {
             String callBackURL = info.getCallBackURL();
-            String[] callbackURLs = callBackURL.trim().split("\\s*,\\s*");
-            clientInfo.setRedirectUris(Arrays.asList(callbackURLs));
+            clientInfo.setRedirectUris(Arrays.asList(extractCallbackURLs(callBackURL)));
         }
 
         clientInfo.setClientName(oauthClientName);
@@ -683,6 +696,22 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
     }
 
     /**
+     * Converts the redirected URIs returned by the DCR endpoint back into a comma-separated callback URL
+     * string, decoding the "regexp=(url1|url2)" pattern IS uses to store multiple callback URLs
+     */
+    private String buildCallbackURL(List<String> redirectUris) {
+        if (redirectUris.size() == 1
+                && redirectUris.get(0).startsWith(WSO2IS7KeyManagerConstants.CALLBACK_URL_REGEXP_PREFIX)
+                && redirectUris.get(0).endsWith(")")) {
+            String regexValue = redirectUris.get(0);
+            String urls = regexValue.substring(WSO2IS7KeyManagerConstants.CALLBACK_URL_REGEXP_PREFIX.length(),
+                    regexValue.length() - 1);
+            return String.join(",", urls.split("\\|"));
+        }
+        return String.join(",", redirectUris);
+    }
+
+    /**
      * Copied from AMDefaultKeyManagerImpl.
      * Builds an OAuthApplicationInfo object using the ClientInfo response
      *
@@ -696,9 +725,9 @@ public class WSO2IS7KeyManager extends AbstractKeyManager {
         oAuthApplicationInfo.setClientName(appResponse.getClientName());
         oAuthApplicationInfo.setClientId(appResponse.getClientId());
         if (appResponse.getRedirectUris() != null) {
-            oAuthApplicationInfo.setCallBackURL(String.join(",", appResponse.getRedirectUris()));
-            oAuthApplicationInfo.addParameter(ApplicationConstants.OAUTH_REDIRECT_URIS,
-                    String.join(",", appResponse.getRedirectUris()));
+            String callBackURL = buildCallbackURL(appResponse.getRedirectUris());
+            oAuthApplicationInfo.setCallBackURL(callBackURL);
+            oAuthApplicationInfo.addParameter(ApplicationConstants.OAUTH_CALLBACK_URIS, callBackURL);
         }
         oAuthApplicationInfo.setClientSecret(appResponse.getClientSecret());
         if (appResponse.getGrantTypes() != null) {

--- a/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManagerConstants.java
+++ b/components/wso2is7.key.manager/src/main/java/org/wso2/is7/client/WSO2IS7KeyManagerConstants.java
@@ -33,6 +33,7 @@ public class WSO2IS7KeyManagerConstants {
     public static final String PKCE_SUPPORT_PLAIN = "ext_pkce_support_plain";
     public static final String PUBLIC_CLIENT = "ext_public_client";
     public static final String REFRESH_TOKEN_TYPE = "Refresh";
+    public static final String CALLBACK_URL_REGEXP_PREFIX = "regexp=(";
 
     /**
      * Constants related to WSO2 Identity Server 7 Key Manager Connector Configuration.

--- a/components/wso2is7.key.manager/src/test/java/org/wso2/is7/client/WSO2IS7KeyManagerTest.java
+++ b/components/wso2is7.key.manager/src/test/java/org/wso2/is7/client/WSO2IS7KeyManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.is7.client;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class WSO2IS7KeyManagerTest {
+
+    private WSO2IS7KeyManager keyManager;
+
+    @Before
+    public void setUp() {
+        keyManager = mock(WSO2IS7KeyManager.class);
+    }
+
+    private String[] invokeExtractCallbackURLs(String callBackURL) throws Exception {
+        Method method = WSO2IS7KeyManager.class.getDeclaredMethod("extractCallbackURLs", String.class);
+        method.setAccessible(true);
+        return (String[]) method.invoke(keyManager, callBackURL);
+    }
+
+    private String invokeBuildCallBackURL(List<String> redirectUris) throws Exception {
+        Method method = WSO2IS7KeyManager.class.getDeclaredMethod("buildCallbackURL", List.class);
+        method.setAccessible(true);
+        return (String) method.invoke(keyManager, redirectUris);
+    }
+
+    @Test
+    public void testExtractCallbackURLsSingleURL() throws Exception {
+        String[] result = invokeExtractCallbackURLs("http://hello:9443");
+        assertArrayEquals(new String[]{"http://hello:9443"}, result);
+    }
+
+    @Test
+    public void testExtractCallbackURLsCommaSeparated() throws Exception {
+        String[] result = invokeExtractCallbackURLs("http://hello:9443,https://heloo123");
+        assertArrayEquals(new String[]{"http://hello:9443", "https://heloo123"}, result);
+    }
+
+    @Test
+    public void testExtractCallbackURLsCommaSeparatedWithSpaces() throws Exception {
+        String[] result = invokeExtractCallbackURLs("http://hello:9443 , https://heloo123 , https://third");
+        assertArrayEquals(new String[]{"http://hello:9443", "https://heloo123", "https://third"}, result);
+    }
+
+    @Test
+    public void testExtractCallbackURLsRegexpFormatTwoURLs() throws Exception {
+        String[] result = invokeExtractCallbackURLs("regexp=(http://hello:9443|https://heloo123)");
+        assertArrayEquals(new String[]{"http://hello:9443", "https://heloo123"}, result);
+    }
+
+    @Test
+    public void testExtractCallbackURLsRegexpFormatThreeURLs() throws Exception {
+        String[] result = invokeExtractCallbackURLs("regexp=(http://a|http://b|http://c)");
+        assertArrayEquals(new String[]{"http://a", "http://b", "http://c"}, result);
+    }
+
+    @Test
+    public void testBuildCallBackURLSingleURL() throws Exception {
+        String result = invokeBuildCallBackURL(Collections.singletonList("http://hello:9443"));
+        assertEquals("http://hello:9443", result);
+    }
+
+    @Test
+    public void testBuildCallBackURLRegexpFormatTwoURLs() throws Exception {
+        String result = invokeBuildCallBackURL(
+                Collections.singletonList("regexp=(http://hello:9443|https://heloo123)"));
+        assertEquals("http://hello:9443,https://heloo123", result);
+    }
+
+    @Test
+    public void testBuildCallBackURLRegexpFormatThreeURLs() throws Exception {
+        String result = invokeBuildCallBackURL(Collections.singletonList("regexp=(http://a|http://b|http://c)"));
+        assertEquals("http://a,http://b,http://c", result);
+    }
+
+    @Test
+    public void testBuildCallBackURLMultipleEntries() throws Exception {
+        String result = invokeBuildCallBackURL(Arrays.asList("http://hello:9443", "https://heloo123"));
+        assertEquals("http://hello:9443,https://heloo123", result);
+    }
+
+    @Test
+    public void testBuildCallBackURLEmptyList() throws Exception {
+        String result = invokeBuildCallBackURL(Collections.emptyList());
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testRoundTripPreservesOriginalCallbackURLs() throws Exception {
+        // Multiple URLs sent to IS get stored/returned encoded as regexp=(url1|url2);
+        // a subsequent save must decode that back to the original comma-separated list
+        String original = "http://hello:9443,https://heloo123";
+        String[] sentToIS = invokeExtractCallbackURLs(original);
+
+        String storedByIS = "regexp=(" + String.join("|", sentToIS) + ")";
+
+        String decodedBack = invokeBuildCallBackURL(Collections.singletonList(storedByIS));
+        assertEquals(original, decodedBack);
+        assertArrayEquals(sentToIS, invokeExtractCallbackURLs(decodedBack));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.api.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powermock.version}</version>
@@ -497,10 +503,11 @@
         <identity.auth.rest.version>1.6.1</identity.auth.rest.version>
         <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
         <com.google.code.gson.version>2.8.5</com.google.code.gson.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
         <mockito.version>2.28.2</mockito.version>
         <powermock.version>2.0.2</powermock.version>
         <mockito.all.version>1.10.19</mockito.all.version>
+        <log4j.api.version>2.17.1</log4j.api.version>
         <openfeign.version>13.2.1</openfeign.version>
         <charon3.version>4.0.19</charon3.version>
         <orbit.version.axis2>${axis2.wso2.version}</orbit.version.axis2>


### PR DESCRIPTION
## Purpose
Fixes a 400 error when updating a DevPortal application's callback URLs while using an external WSO2 IS (7.1+) as the Key Manager.

WSO2 IS stores an application's callback URL as a single value. When more than one callback URL is registered, IS encodes them into one string using a `regexp=(url1|url2)` pattern (since its Service Provider model has no native multi-value callback field).                                                                                                                                                               
                                                                                                                                                                                                                 
APIM's `WSO2IS7KeyManager` was reading that encoded value straight into the application's callback URL field, so after saving and refreshing, DevPortal displayed:
                                             
```
regexp=(http://hello:9443|https://heloo123)                                                                                                                                                                    
```
Then, on the next save, this literal string was sent back to IS's DCR endpoint as a single (malformed) redirect URI, which IS rejected with a 400 , because `regexp=(...)` is not a valid URI on its own, only meaningful as IS's internal encoding.                                                                                                                                                                          
                                                                                                                                                                                                                This is the same symptom previously fixed for the resident/default Key Manager (#9328), but that fix never covered the external IS Key Manager path.

#### Fix:
- [[DevPortal] Cannot update multiple callback URLs when using IS 7.1 as external Key Manager #4679](https://github.com/wso2/api-manager/issues/4679)
- [Cannot update multiple callback urls in application with IS 7.1 as KM #4702](https://github.com/wso2/api-manager/issues/4702)
- [[DevPortal]Cannot update multiple callback urls in application #9328](https://github.com/wso2/product-apim/issues/9328)


## Fix 
`WSO2IS7KeyManager` now decodes the `regexp=(url1|url2)` pattern in both directions:                                                                                                                           
  - **Reading from IS**:  converts it back into a proper comma-separated callback URL string for display.                                                                                                        
  - **Sending to IS**: detects the pattern (instead of blindly splitting on commas) so multiple callback URLs are correctly split into individual redirect URIs.

This makes the round-trip lossless: DevPortal always shows and re-submits callback URLs in their original comma-separated form, so repeated updates no longer fail.           